### PR TITLE
Fix Diameter_client.py installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,7 @@ RUN git clone https://github.com/nickvsnetworking/pyhss.git
 WORKDIR pyhss
 RUN mkdir -p log
 RUN pip3 install -r requirements.txt
+RUN cp /pyhss/tools/Diameter_client.py /pyhss/
 COPY config.yaml .
 COPY pyhss_init.sh .
 CMD sh pyhss_init.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 redis==3.5.3
+construct==2.10.68
 pycryptodome==3.14.1
 pycryptodomex==3.9.7
 pyyaml==5.3.1


### PR DESCRIPTION
This PR updates Docker image definition and python dependencies in order to be able to run `tools/Diameter_client.py` from `/pyhss` directory in the Docker container.