### PR TITLE
IPv6 Formatting Fixes

### DIFF
--- a/diameter.py
+++ b/diameter.py
@@ -7,6 +7,7 @@ import binascii
 import math
 import uuid
 import os
+import ipaddress
 sys.path.append(os.path.realpath('lib'))
 import S6a_crypt
 
@@ -57,11 +58,7 @@ class Diameter:
             ip_hex = ip_hex + str(format(int(ip[3]), 'x').zfill(2))
         else:
             ip_hex = "0002"         #IPv6
-            for parts in ip.split(":"):
-                if parts == '':
-                    ip_hex += "00000000"    #If :: represent as full
-                else:
-                    ip_hex += str(parts).zfill(4)
+            ip_hex += format(ipaddress.IPv6Address(ip), 'X')
         #DiameterLogger.debug("Converted IP to hex - Input: " + str(ip) + " output: " + str(ip_hex))
         return ip_hex
     #Converts a hex formatted IPv4 address or IPV6 address to dotted-decimal 


### PR DESCRIPTION
Fixes output for ipv6 in ip_to_hex (diameter.py)

Output before
```
::                 0002000000000000000000000000
2001::1            00022001000000000001
2001:abcd::1       00022001abcd000000000001
2001:0:0:0:0:0:0:1 000220010000000000000000000000000001
0.0.0.0            000100000000
```

Output after patch

```
::                 000200000000000000000000000000000000
2001::1            000220010000000000000000000000000001
2001:abcd::1       00022001ABCD000000000000000000000001
2001:0:0:0:0:0:0:1 000220010000000000000000000000000001
0.0.0.0            000100000000
```
