### PR TITLE
Fixed APN PDN type to take type from the database field ip_version

### DIFF
--- a/database.py
+++ b/database.py
@@ -46,7 +46,7 @@ class APN(Base):
     __tablename__ = 'apn'
     apn_id = Column(Integer, primary_key=True, doc='Unique ID of APN')
     apn = Column(String(50), nullable=False, doc='Short name of the APN')
-    ip_version = Column(Integer, default=4, doc="IP version used - 0: ipv4, 1: ipv6 2: ipv4+6 3: ipv4 or ipv6 [3GPP TS 29.272 7.3.62]")
+    ip_version = Column(Integer, default=0, doc="IP version used - 0: ipv4, 1: ipv6 2: ipv4+6 3: ipv4 or ipv6 [3GPP TS 29.272 7.3.62]")
     pgw_address = Column(String(50), doc='IP of the PGW')
     sgw_address = Column(String(50), doc='IP of the SGW')
     charging_characteristics = Column(String(4), default='0800', doc='For the encoding of this information element see 3GPP TS 32.298 [9]')

--- a/diameter.py
+++ b/diameter.py
@@ -678,7 +678,7 @@ class Diameter:
             DiameterLogger.debug("Setting APN Configuration Profile")
             #Sub AVPs of APN Configuration Profile
             APN_context_identifer = self.generate_vendor_avp(1423, "c0", 10415, self.int_to_hex(APN_context_identifer_count, 4))
-            APN_PDN_type = self.generate_vendor_avp(1456, "c0", 10415, self.int_to_hex(0, 4))
+            APN_PDN_type = self.generate_vendor_avp(1456, "c0", 10415, self.int_to_hex(int(apn_data['ip_version']), 4))
             
             DiameterLogger.debug("Setting APN AMBR")
             #AMBR


### PR DESCRIPTION
Allows for the ip_version field from the database to be used in the APN-PDN-TYPE