### PR TITLE
Fix avp reference before assignment in Answer_16777252_324

### DIFF
--- a/diameter.py
+++ b/diameter.py
@@ -1490,12 +1490,11 @@ class Diameter:
     def Answer_16777252_324(self, packet_vars, avps):
         logtool.RedisIncrimenter('Answer_16777252_324_attempt_count')
 
-        avp = ''                                                                                            #Initiate empty var AVP
         #Get IMSI
         try:
             imsi = self.get_avp_data(avps, 1)[0]                                                            #Get IMSI from User-Name AVP in request
             imsi = binascii.unhexlify(imsi).decode('utf-8')                                                 #Convert IMSI
-            avp += self.generate_avp(1, 40, self.string_to_hex(imsi))                                       #Username (IMSI)
+            #avp += self.generate_avp(1, 40, self.string_to_hex(imsi))                                      #Username (IMSI)
             DiameterLogger.info("Got IMSI with value " + str(imsi))
         except Exception as e:
             DiameterLogger.debug("Failed to get IMSI from LCS-Routing-Info-Request")
@@ -1508,6 +1507,7 @@ class Diameter:
                 imei = binascii.unhexlify(sub_avp['misc_data']).decode('utf-8')
                 DiameterLogger.debug("Found IMEI " + str(imei))
 
+        avp = ''                                                                                        #Initiate empty var AVP
         session_id = self.get_avp_data(avps, 263)[0]                                                    #Get Session-ID
         avp += self.generate_avp(263, 40, session_id)                                                   #Set session ID to received session ID
         avp += self.generate_avp(260, 40, "0000010a4000000c000028af000001024000000c01000024")           #Vendor-Specific-Application-ID for S13

--- a/diameter.py
+++ b/diameter.py
@@ -1490,6 +1490,7 @@ class Diameter:
     def Answer_16777252_324(self, packet_vars, avps):
         logtool.RedisIncrimenter('Answer_16777252_324_attempt_count')
 
+        avp = ''
         #Get IMSI
         try:
             imsi = self.get_avp_data(avps, 1)[0]                                                            #Get IMSI from User-Name AVP in request

--- a/diameter.py
+++ b/diameter.py
@@ -1490,7 +1490,7 @@ class Diameter:
     def Answer_16777252_324(self, packet_vars, avps):
         logtool.RedisIncrimenter('Answer_16777252_324_attempt_count')
 
-        avp = ''
+        avp = ''                                                                                            #Initiate empty var AVP
         #Get IMSI
         try:
             imsi = self.get_avp_data(avps, 1)[0]                                                            #Get IMSI from User-Name AVP in request
@@ -1508,7 +1508,6 @@ class Diameter:
                 imei = binascii.unhexlify(sub_avp['misc_data']).decode('utf-8')
                 DiameterLogger.debug("Found IMEI " + str(imei))
 
-        avp = ''                                                                                        #Initiate empty var AVP                                                                                           #Session-ID
         session_id = self.get_avp_data(avps, 263)[0]                                                    #Get Session-ID
         avp += self.generate_avp(263, 40, session_id)                                                   #Set session ID to received session ID
         avp += self.generate_avp(260, 40, "0000010a4000000c000028af000001024000000c01000024")           #Vendor-Specific-Application-ID for S13


### PR DESCRIPTION
Fix for:

Feb 28 04:53:14 hss06 python3[114218]: 2023-02-28 04:53:14,382          DEBUG          {/etc/pyhss/diameter.py:1501}          Failed to get IMSI from LCS-Routing-Info-Request
Feb 28 04:53:14 hss06 python3[114218]: DEBUG:DiameterLogger:Failed to get IMSI from LCS-Routing-Info-Request
Feb 28 04:53:14 hss06 python3[114218]: Failed to get IMSI from LCS-Routing-Info-Request
Feb 28 04:53:14 hss06 python3[114218]: 2023-02-28 04:53:14,383          DEBUG          {/etc/pyhss/diameter.py:1502}          Error was: local variable 'avp' referenced before assignment
Feb 28 04:53:14 hss06 python3[114218]: DEBUG:DiameterLogger:Error was: local variable 'avp' referenced before assignment
Feb 28 04:53:14 hss06 python3[114218]: Error was: local variable 'avp' referenced before assignment