### PR TITLE
Fix attach without charging rules in the DB

### DIFF
--- a/lib/database.py
+++ b/lib/database.py
@@ -2152,7 +2152,7 @@ class Database:
                 ChargingRule['apn_data'] = apn_data
 
                 #Get Charging Rules list
-                if apn_data['charging_rule_list'] == None:
+                if not apn_data['charging_rule_list'] or apn_data['charging_rule_list'].strip() == '':
                     self.logTool.log(service='Database', level='debug', message="No Charging Rule associated with this APN", redisClient=self.redisMessaging)
                     ChargingRule['charging_rules'] = None
                     return ChargingRule


### PR DESCRIPTION
Original check fails if there are no charging rules added to the APN config. 
This small modification allows attach to be completed successfully without charging rules assigned.