### PR TITLE
CLR Issue on New Subscriber

### DIFF
--- a/lib/database.py
+++ b/lib/database.py
@@ -1693,12 +1693,12 @@ class Database:
             result = session.query(SUBSCRIBER).filter_by(imsi=imsi).one()
             if self.config['hss']['CancelLocationRequest_Enabled'] == True:
                 self.logTool.log(service='Database', level='debug', message="Evaluating if we should trigger sending a CLR.", redisClient=self.redisMessaging)
-                serving_hss = str(result.serving_mme_peer).split(';',1)[1]
-                serving_mme_peer = str(result.serving_mme_peer).split(';',1)[0]
-                self.logTool.log(service='Database', level='debug', message="Subscriber is currently served by serving_mme: " + str(result.serving_mme) + " at realm " + str(result.serving_mme_realm) + " through Diameter peer " + str(result.serving_mme_peer), redisClient=self.redisMessaging)
-                self.logTool.log(service='Database', level='debug', message="Subscriber is now       served by serving_mme: " + str(serving_mme) + " at realm " + str(serving_mme_realm) + " through Diameter peer " + str(serving_mme_peer), redisClient=self.redisMessaging)
-                #Evaluate if we need to send a CLR to the old MME
                 if result.serving_mme != None:
+                    serving_hss = str(result.serving_mme_peer).split(';',1)[1]
+                    serving_mme_peer = str(result.serving_mme_peer).split(';',1)[0]
+                    self.logTool.log(service='Database', level='debug', message="Subscriber is currently served by serving_mme: " + str(result.serving_mme) + " at realm " + str(result.serving_mme_realm) + " through Diameter peer " + str(result.serving_mme_peer), redisClient=self.redisMessaging)
+                    self.logTool.log(service='Database', level='debug', message="Subscriber is now       served by serving_mme: " + str(serving_mme) + " at realm " + str(serving_mme_realm) + " through Diameter peer " + str(serving_mme_peer), redisClient=self.redisMessaging)
+                    #Evaluate if we need to send a CLR to the old MME
                     if str(result.serving_mme) == str(serving_mme):
                         self.logTool.log(service='Database', level='debug', message="This MME is unchanged (" + str(serving_mme) + ") - so no need to send a CLR", redisClient=self.redisMessaging)
                     elif (str(result.serving_mme) != str(serving_mme)):


### PR DESCRIPTION
When this line is executed for a subscriber that does not have a `serving_mme_peer` defined, the Serving MME isn't able to be updated.

`serving_hss = str(result.serving_mme_peer).split(';',1)[1]`

I get this error:

`[ERROR] Error occurred in Update_Serving_MME: list index out of range`

I'm proposing that the None check on this string be moved a bit earlier in the code.