### PR TITLE
database.py: add support for sqlite

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -127,11 +127,11 @@ logging:
 
 ## Database Parameters
 database:
-  db_type: mysql    #Supported types are MySQL and Postgres
+  db_type: mysql    #Supported types are MySQL, Postgres and sqlite
   server: 127.0.0.1
   username: dbeaver
   password: password
-  database: hss2
+  database: hss2 # for sqlite, this should be a path to the database file
   readCacheEnabled: True
   readCacheInterval: 60
 

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -1,7 +1,7 @@
 # PyHSS - Database Notes
 PyHSS now uses Python SQLalchemy to abstract away the database component.
 
-Tested backends are Postgres and MySQL, but in theory any database supporting SQLalchemy could be used.
+Tested backends are Postgres, MySQL and sqlite but in theory any database supporting SQLalchemy could be used.
 
 The schema is quite simple, but rather than interacting directly with the Schema, a [RESTful API](api.md) allows for easy, safe CRUD operations on the subscriber data.
 

--- a/lib/database.py
+++ b/lib/database.py
@@ -356,11 +356,17 @@ class Database:
         else:
             self.redisMessaging = RedisMessaging(host=self.redisHost, port=self.redisPort, useUnixSocket=self.redisUseUnixSocket, unixSocketPath=self.redisUnixSocketPath)
 
-        if str(self.config['database']['db_type']) == 'postgresql':
+        db_type = str(self.config['database']['db_type'])
+
+        if db_type == 'postgresql':
             db_string = 'postgresql+psycopg2://' + str(self.config['database']['username']) + ':' + str(self.config['database']['password']) + '@' + str(self.config['database']['server']) + '/' + str(self.config['database']['database'])
-        else:
+        elif db_type == 'mysql':
             db_string = 'mysql://' + str(self.config['database']['username']) + ':' + str(self.config['database']['password']) + '@' + str(self.config['database']['server']) + '/' + str(self.config['database']['database'] + "?autocommit=true")
-        
+        elif db_type == 'sqlite':
+            db_string = "sqlite:///" + str(self.config['database']['database'])
+        else:
+            raise RuntimeError(f'Invalid database.db_type set "{db_type}"')
+
         self.hostname = socket.gethostname()        
         
         self.engine = create_engine(


### PR DESCRIPTION
sqlalchemy already supports sqlite as db backend.
To use sqlite configure:
- database.db_type: sqlite
- database.database : /path/to/sqlite/file

All remaining database settings are ignored for sqlite.

We have tested this and it works beautifully for smaller installations.