### PR TITLE
Implement GSUP support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -93,6 +93,9 @@ hss:
     rtoMin: 500
     rtoInitial: 1000
 
+  gsup:
+    bind_ip: "0.0.0.0"
+    bind_port: 4222
 
 api:
   page_size: 200

--- a/lib/S6a_crypt.py
+++ b/lib/S6a_crypt.py
@@ -1,6 +1,7 @@
+from comp128.comp128v1 import Comp128v1
+from comp128.comp128v23 import Comp128v23
 from milenage import Milenage
 import binascii
-import base64
 import logging
 import os
 import sys
@@ -110,6 +111,54 @@ def generate_maa_vector(key, op_c, amf, sqn, plmn):
     # print("ck: " + str(ck))
     # print("ik: " + str(ik))
     return (rand, autn, xres, ck, ik)
+
+
+def generate_2g3g_vector(key, op_c, amf, sqn, algo):
+    CryptoLogger.debug("Generating 2G/3G Authentication Vector")
+    key = key.encode('utf-8')
+    CryptoLogger.debug("Input K:  " + str(key))
+    key = binascii.unhexlify(key)
+
+    op_c = op_c.encode('utf-8')
+    CryptoLogger.debug("Input OPc:  " + str(op_c))
+    op_c = binascii.unhexlify(op_c)
+
+    amf = str(amf)
+    amf = amf.encode('utf-8')
+    amf = binascii.unhexlify(amf)
+    CryptoLogger.debug("Input AMF: " + str(amf))
+
+    sqn = int(sqn)
+    CryptoLogger.debug("Input SQN: " + str(sqn))
+
+    kc = None
+    sres = None
+    rand = Milenage.generate_rand()
+
+    if algo == 1:
+        crypto_obj = Comp128v1()
+        sres, kc = crypto_obj.comp128v1(bytearray(key), rand)
+    elif algo == 2:
+        crypto_obj = Comp128v23()
+        sres, kc = crypto_obj.comp128v2(bytearray(key), rand)
+    elif algo == 3:
+        crypto_obj = Comp128v23()
+        sres, kc = crypto_obj.comp128v3(bytearray(key), rand, sres, kc)
+
+    # Case: SIM only supports 2G Auth
+    if op_c == b'':
+        return dict(rand=rand, sres=sres, kc=kc)
+
+    crypto_obj = Milenage(amf)
+    (res, milenage_sres, autn, ck, ik, milenage_kc) = crypto_obj.generate_2g3g_vector(key, op_c, rand, sqn)
+
+    # Case: SIM supports both 2G and 3G Auth -> leave kc and sres as is
+    # Case: SIM only supports 3G Auth -> overwrite kc and sres with milenage values
+    if sres is None or kc is None:
+        sres = milenage_sres
+        kc = milenage_kc
+
+    return dict(rand=rand, autn=autn, res=res, sres=sres, ck=ck, ik=ik, kc=kc)
 
 def generate_eap_aka_vector(key, op_c, amf, sqn, plmn):
     CryptoLogger.debug("Generating EAP-AKA Vector")

--- a/lib/banners.py
+++ b/lib/banners.py
@@ -108,3 +108,21 @@ class Banners:
 
 """
         return bannerText
+
+    def gsupService(self) -> str:
+        bannerText = """
+
+         ######            ##   ##   #####    #####  
+         ##   ##           ##   ##  ##   ##  ##   ## 
+         ##   ##  ##  ##   ##   ##  ##       ##      
+         ######   ##  ##   #######   #####    #####  
+         ##       ##  ##   ##   ##       ##       ## 
+         ##       ##  ##   ##   ##  ##   ##  ##   ## 
+         ##        #####   ##   ##   #####    #####  
+                      ##                             
+                   ####                              
+
+                        GSUP Service
+
+        """
+        return bannerText

--- a/lib/gsup/controller/abstract_controller.py
+++ b/lib/gsup/controller/abstract_controller.py
@@ -1,0 +1,46 @@
+"""
+    PyHSS GSUP Request Controller base class
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from abc import abstractmethod, ABC
+
+from osmocom.gsup.message import GsupMessage
+
+from database import Database
+from gsup.protocol.ipa_peer import IPAPeer
+from gsup.protocol.osmocom_ipa import IPA
+from logtool import LogTool
+
+
+class GsupController(ABC):
+    def __init__(self, logger: LogTool, database: Database):
+        self._logger = logger
+        self._database = database
+        self._ipa = IPA()
+
+    @abstractmethod
+    async def handle_message(self, peer: IPAPeer, message: GsupMessage):
+        pass
+
+    async def _send_gsup_response(self, peer: IPAPeer, response: GsupMessage):
+        data = response.to_bytes()
+        data = IPA.add_header(data, self._ipa.PROTO['OSMO'], self._ipa.EXT['GSUP'])
+        peer.writer.write(data)
+        await peer.writer.drain()

--- a/lib/gsup/controller/air.py
+++ b/lib/gsup/controller/air.py
@@ -1,0 +1,73 @@
+"""
+    PyHSS GSUP Authentication Info Request Controller
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import traceback
+
+from osmocom.gsup.message import GsupMessage, MsgType
+
+from database import Database
+from gsup.controller.abstract_controller import GsupController
+from gsup.protocol.gsup_msg import GsupMessageUtil, GsupMessageBuilder
+from gsup.protocol.ipa_peer import IPAPeer
+from logtool import LogTool
+
+
+class AIRController(GsupController):
+    def __init__(self, logger: LogTool, database: Database):
+        super().__init__(logger, database)
+
+    async def handle_message(self, peer: IPAPeer, message: GsupMessage):
+        request_dict = message.to_dict()
+        imsi = GsupMessageUtil.get_first_ie_by_name(GsupMessageUtil.GSUP_MSG_IE_IMSI, request_dict)
+        if imsi is None:
+            await self._logger.logAsync(service='GSUP', level='WARN',
+                                        message=f"Missing IMSI in GSUP message from {peer}. Responding with error.")
+            await self._send_gsup_response(peer, GsupMessageBuilder().with_msg_type(
+                MsgType.SEND_AUTH_INFO_ERROR).build())
+            return
+
+        try:
+            subscriber = self._database.Get_Subscriber(imsi=imsi)
+            rand = GsupMessageUtil.get_first_ie_by_name('rand', request_dict)
+            auts = GsupMessageUtil.get_first_ie_by_name('auts', request_dict)
+
+            resync_required = rand is not None and auts is not None
+            if resync_required:
+                self._database.Get_Vectors_AuC(subscriber['auc_id'], 'sqn_resync', rand=rand, auts=auts.hex())
+            vectors = self._database.Get_Vectors_AuC(subscriber['auc_id'], '2g3g', requested_vectors=1)
+
+            response_msg = ((GsupMessageBuilder()
+                             .with_msg_type(MsgType.SEND_AUTH_INFO_RESULT))
+                            .with_ie('imsi', imsi)
+                            .with_ie('auth_tuple', vectors))
+
+            response_msg = response_msg.build()
+
+            await self._send_gsup_response(peer, response_msg)
+
+        except ValueError as e:
+            await self._logger.logAsync(service='GSUP', level='WARN', message=f"Subscriber not found: {imsi}")
+            await self._send_gsup_response(peer, GsupMessageBuilder().with_msg_type(
+                MsgType.SEND_AUTH_INFO_ERROR).with_ie('imsi', imsi).build())
+        except Exception as e:
+            await self._logger.logAsync(service='GSUP', level='ERROR', message=f"Error handling GSUP message: {str(e)}, {traceback.format_exc()}")
+            await self._send_gsup_response(peer, GsupMessageBuilder().with_msg_type(
+                MsgType.SEND_AUTH_INFO_ERROR).with_ie('imsi', imsi).build())

--- a/lib/gsup/controller/isr.py
+++ b/lib/gsup/controller/isr.py
@@ -1,0 +1,45 @@
+"""
+    PyHSS GSUP Insert Subscriber Data Request Controller
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from typing import Dict
+
+from osmocom.gsup.message import GsupMessage
+
+from database import Database
+from gsup.controller.abstract_controller import GsupController
+from gsup.controller.ulr import ULRTransaction
+from gsup.protocol.ipa_peer import IPAPeer
+from logtool import LogTool
+
+
+class ISRController(GsupController):
+    def __init__(self, logger: LogTool, database: Database, ulr_transactions: Dict[str, ULRTransaction]):
+        super().__init__(logger, database)
+        self.__ulr_transactions = ulr_transactions
+
+    async def handle_message(self, peer: IPAPeer, message: GsupMessage):
+        if peer.name not in self.__ulr_transactions:
+            raise ValueError(f"ULR Transaction for peer {peer.name} not found")
+        transaction = self.__ulr_transactions[peer.name]
+        if transaction.is_finished():
+            raise ValueError(f"ULR Transaction for peer {peer.name} is already finished")
+
+        await transaction.handle_insert_subscriber_data_response(message)

--- a/lib/gsup/controller/noop.py
+++ b/lib/gsup/controller/noop.py
@@ -1,0 +1,34 @@
+"""
+    PyHSS GSUP Noop Controller - A controller that does nothing for a given message (e.g. like an answer)
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from osmocom.gsup.message import GsupMessage
+
+from database import Database
+from gsup.controller.abstract_controller import GsupController
+from gsup.protocol.ipa_peer import IPAPeer
+from logtool import LogTool
+
+
+class NoopController(GsupController):
+    def __init__(self, logger: LogTool, database: Database):
+        super().__init__(logger, database)
+
+    async def handle_message(self, peer: IPAPeer, message: GsupMessage):
+        await self._logger.logAsync(service='GSUP', level='DEBUG', message=f"Nothing to do for {message.msg_type.name} from {peer}. Ignoring.")

--- a/lib/gsup/controller/pur.py
+++ b/lib/gsup/controller/pur.py
@@ -1,0 +1,48 @@
+"""
+    PyHSS GSUP PurgeUE Controller
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from osmocom.gsup.message import MsgType
+
+from gsup.controller.abstract_controller import GsupController
+from gsup.protocol.gsup_msg import GsupMessageUtil, GsupMessageBuilder
+
+
+class PURController(GsupController):
+    def __init__(self, logger, database):
+        super().__init__(logger, database)
+
+    async def handle_message(self, peer, message):
+        imsi = GsupMessageUtil.get_first_ie_by_name('imsi', message.to_dict())
+        if imsi is None:
+            await self._logger.logAsync(service='GSUP', level='WARN', message=f"IMSI not found in PUR message from {peer}")
+            response = GsupMessageBuilder().with_msg_type(MsgType.PURGE_MS_ERROR).build()
+            await self._send_gsup_response(peer, response)
+            return
+
+        try:
+            self._database.update_gsup(imsi, peer.role, None)
+            await self._logger.logAsync(service='GSUP', level='INFO', message=f"Subscriber {imsi} purged from {peer}")
+            response = GsupMessageBuilder().with_msg_type(MsgType.PURGE_MS_RESULT).with_ie('imsi', imsi).build()
+            await self._send_gsup_response(peer, response)
+        except Exception as e:
+            await self._logger.logAsync(service='GSUP', level='ERROR', message=f"Error purging subscriber: {str(e)}")
+            response = GsupMessageBuilder().with_msg_type(MsgType.PURGE_MS_ERROR).with_ie('imsi', imsi).build()
+            await self._send_gsup_response(peer, response)

--- a/lib/gsup/controller/ulr.py
+++ b/lib/gsup/controller/ulr.py
@@ -1,0 +1,195 @@
+"""
+    PyHSS GSUP Update Location Request Controller
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import traceback
+from datetime import datetime
+from enum import IntEnum
+from typing import Callable, List, Dict, Optional
+from osmocom.gsup.message import GsupMessage, MsgType
+
+from database import Database
+from gsup.controller.abstract_controller import GsupController
+from gsup.protocol.gsup_msg import GsupMessageBuilder, GsupMessageUtil
+from gsup.protocol.ipa_peer import IPAPeer, IPAPeerRole
+from logtool import LogTool
+
+
+class ULRSubscriberInfo:
+    def __init__(self, apns: List[Dict[str, str]], msisdn: str, imsi: str):
+        self.apns = apns
+        self.msisdn = msisdn
+        self.imsi = imsi
+
+
+class ULRTransaction:
+    class __TransactionState(IntEnum):
+        BEGIN_STATE_INITIAL = 0
+        ISD_REQUEST_SENT = 1
+        END_STATE_ULR_SENT = 2
+        END_STATE_CANCEL_LOCATION_SENT = 3
+
+    def __init__(self, peer: IPAPeer, ulr: GsupMessage, cb_response_sender: Callable[[IPAPeer, GsupMessage], None],
+                 cb_update_subscriber: Callable[[IPAPeer, str], Optional[IPAPeer]], subscriber_info: ULRSubscriberInfo):
+        self.__peer = peer
+        self.__ulr = ulr.to_dict()
+        self.__subscriber_info = subscriber_info
+        self.__cb_response_sender = cb_response_sender
+        self.__cb_update_subscriber = cb_update_subscriber
+        self.__insert_subscriber_data_response = None
+        self.__state = self.__TransactionState.BEGIN_STATE_INITIAL
+        self.__old_peer = None
+        self.__timeout_seconds = 10
+        self.__started_at = datetime.now()
+
+    async def begin(self):
+        if self.__state != self.__TransactionState.BEGIN_STATE_INITIAL:
+            raise ValueError("ULR Transaction already started")
+
+        await self.__send_isd_request()
+        self.__state = self.__TransactionState.ISD_REQUEST_SENT
+
+    async def handle_insert_subscriber_data_response(self, response: GsupMessage):
+        if self.__state != self.__TransactionState.ISD_REQUEST_SENT:
+            raise ValueError("ULR Transaction not in ISD_REQUEST_SENT state")
+
+        self.__insert_subscriber_data_response = response
+        await self.__handle_insert_subscriber_data_response()
+        if self.__old_peer is not None and self.__old_peer.primary_id != self.__peer.primary_id:
+            await self.__send_cancel_location_request()
+
+    def is_finished(self):
+        if self.__is_timed_out():
+            return True
+
+        if self.__state == self.__TransactionState.END_STATE_ULR_SENT:
+            return self.__old_peer is None
+
+        return self.__state == self.__TransactionState.END_STATE_CANCEL_LOCATION_SENT
+
+    def __is_timed_out(self):
+        return (datetime.now() - self.__started_at).seconds > self.__timeout_seconds
+
+    async def __send_isd_request(self):
+        request_builder = (GsupMessageBuilder()
+                           .with_msg_type(MsgType.INSERT_DATA_REQUEST)
+                           .with_ie('imsi', self.__subscriber_info.imsi)
+                           .with_msisdn_ie(self.__subscriber_info.msisdn)
+                           .with_ie('destination_name', '')
+                           )
+
+        cn_domain = GsupMessageUtil.get_first_ie_by_name('cn_domain', self.__ulr)
+        if cn_domain == 'ps':
+            for index, apn in enumerate(self.__subscriber_info.apns):
+                request_builder.with_pdp_info_ie(index, apn['ip_version'], apn['name'])
+
+        await self.__cb_response_sender(self.__peer, request_builder.build())
+
+    async def __handle_insert_subscriber_data_response(self):
+        imsi = GsupMessageUtil.get_first_ie_by_name('imsi', self.__insert_subscriber_data_response.to_dict())
+        isd_success = self.__insert_subscriber_data_response.msg_type == MsgType.INSERT_DATA_RESULT
+        if isd_success:
+            self.__old_peer = self.__cb_update_subscriber(self.__peer, imsi)
+        response_builder = (GsupMessageBuilder()
+                            .with_ie('imsi', self.__subscriber_info.imsi)
+                            .with_ie('destination_name', None)
+                            )
+
+        msg_type = MsgType.UPDATE_LOCATION_RESULT
+        if self.__insert_subscriber_data_response.msg_type == MsgType.INSERT_DATA_ERROR:
+            msg_type = MsgType.UPDATE_LOCATION_ERROR
+
+        response_builder.with_msg_type(msg_type)
+        response_builder.with_ie('imsi', self.__subscriber_info.imsi)
+        response = response_builder.build()
+        await self.__cb_response_sender(self.__peer, response)
+        self.__state = self.__TransactionState.END_STATE_ULR_SENT
+
+    async def __send_cancel_location_request(self):
+        request_builder = (GsupMessageBuilder()
+                           .with_msg_type(MsgType.LOCATION_CANCEL_REQUEST)
+                           .with_ie('imsi', self.__subscriber_info.imsi)
+                           .with_ie('destination_name', None)
+                           )
+        await self.__cb_response_sender(self.__old_peer, request_builder.build())
+        self.__state = self.__TransactionState.END_STATE_CANCEL_LOCATION_SENT
+
+
+class ULRController(GsupController):
+    def __init__(self, logger: LogTool, database: Database, ulr_transactions: Dict[str, ULRTransaction], all_peers: Dict[str, IPAPeer]):
+        super().__init__(logger, database)
+        self.__ulr_transactions = ulr_transactions
+        self.__all_ipa_peers = all_peers
+
+    def __update_subscriber(self, peer: IPAPeer, imsi: str) -> Optional[IPAPeer]:
+        old_id = self._database.update_gsup(imsi, peer.role, peer.primary_id)
+
+        if old_id is None:
+            return None
+
+        for peer_name, peer in self.__all_ipa_peers.items():
+            if self.__all_ipa_peers[peer_name].primary_id == old_id:
+                return self.__all_ipa_peers[peer_name]
+        return None
+
+    async def handle_message(self, peer: IPAPeer, message: GsupMessage):
+        imsi = None
+        try:
+            request_dict = message.to_dict()
+            imsi = GsupMessageUtil.get_first_ie_by_name('imsi', request_dict)
+            if imsi is None:
+                raise ValueError(f"Missing IMSI in GSUP message from peer {peer}")
+            subscriber = self._database.Get_Subscriber(imsi=imsi)
+            apns = list()
+            msisdn = subscriber['msisdn']
+
+            ip_version_to_str = {
+                0: 'ipv4',
+                1: 'ipv6',
+                2: 'ipv4v6',
+                3: 'ipv4v6',
+            }
+
+            for apn in apns:
+                db_apn = self._database.Get_APN_by_Name(apn)
+                ip_version_str = None
+                if db_apn['ip_version'] in ip_version_to_str:
+                    ip_version_str = ip_version_to_str[db_apn['ip_version']]
+                apns.append({'name': apn, 'ip_version': ip_version_str})
+
+            subscriber_info = ULRSubscriberInfo(apns, msisdn, imsi)
+
+
+            transaction = ULRTransaction(peer, message, self._send_gsup_response, self.__update_subscriber, subscriber_info)
+            self.__ulr_transactions[peer.name] = transaction
+            await transaction.begin()
+        except ValueError as e:
+            builder = GsupMessageBuilder().with_msg_type(MsgType.UPDATE_LOCATION_ERROR)
+            await self._logger.logAsync(service='GSUP', level='WARN', message=f"Subscriber not found: {imsi} {traceback.format_exc()}")
+            if imsi is not None:
+                builder.with_ie('imsi', imsi)
+            await self._send_gsup_response(peer, builder.build())
+        except Exception as e:
+            await self._logger.logAsync(service='GSUP', level='ERROR', message=f"Error handling GSUP message: {str(e)}")
+            if imsi is not None:
+                await self._send_gsup_response(peer, GsupMessageBuilder().with_msg_type(
+                    MsgType.UPDATE_LOCATION_ERROR).with_ie('imsi', imsi).build())
+            await self._send_gsup_response(peer, GsupMessageBuilder().with_msg_type(
+                MsgType.UPDATE_LOCATION_ERROR).build())

--- a/lib/gsup/protocol/gsup_msg.py
+++ b/lib/gsup/protocol/gsup_msg.py
@@ -1,0 +1,117 @@
+"""
+    PyHSS GSUP Message Builder - A factory class to create new GSUP Messages
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from osmocom.gsup.message import MsgType, GsupMessage
+
+
+class GsupMessageBuilder:
+    def __init__(self):
+        self.gsup_dict = dict()
+        self.gsup_dict['ies'] = list()
+        self.gsup_dict['msg_type'] = ""
+
+    def with_msg_type(self, msg_type: MsgType):
+        self.gsup_dict['msg_type'] = msg_type.name
+        return self
+
+    def with_ie(self, name: str, value):
+        if 'ies' not in self.gsup_dict:
+            self.gsup_dict['ies'] = []
+
+        for ie in self.gsup_dict['ies']:
+            if name in ie and isinstance(ie[name], list) and isinstance(value, dict):
+                ie[name].append(value)
+                return self
+            elif name in ie and isinstance(ie[name], list) and isinstance(value, list):
+                ie[name].extend(value)
+                return self
+
+
+        self.gsup_dict['ies'].append({
+            name: value
+        })
+        return self
+
+    def with_msisdn_ie(self, msisdn: str):
+        ie = {
+            'ton_npi': {
+                'ext': False,
+                'type_of_number': 'unknown',
+                'numbering_plan_id': 'sc_specific_6'
+            },
+            'digits': msisdn
+        }
+        return self.with_ie('msisdn', ie)
+
+    def with_pdp_info_ie(self, pdp_ctx_id: int, pdp_type: str, apn_name: str):
+        pdp_info = GsupMessageUtil.get_first_ie_by_name('pdp_info', self.gsup_dict)
+        if pdp_info is None:
+            pdp_info = []
+
+        pdp_info.append({
+            'pdp_context_id': pdp_ctx_id
+        })
+
+        pdp_info.append({
+            'pdp_address': {
+                'address': None,
+                'hdr': {
+                    'pdp_type_nr': pdp_type,
+                    'pdp_type_org': 'ietf'
+                }
+            }
+        })
+
+        pdp_info.append(
+            {
+                'access_point_name': apn_name
+            }
+        )
+
+        pdp_info.append({'qos': None})
+
+        return self.with_ie('pdp_info', pdp_info)
+
+    def build(self) -> GsupMessage:
+        if 'msg_type' == "":
+            raise ValueError("msg_type is required")
+        return GsupMessage.from_dict(self.gsup_dict)
+
+
+class GsupMessageUtil:
+    GSUP_MSG_IES = "ies"
+    GSUP_MSG_IE_IMSI = "imsi"
+    GSUP_MSG_IE_AUTH_TUPLE = "auth_tuple"
+
+    @staticmethod
+    def get_first_ie_by_name(ie_name: str, message: dict):
+        for ie in message['ies']:
+            if ie_name in ie:
+                return ie[ie_name]
+        return None
+
+    @staticmethod
+    def get_ies_by_name(ie_name: str, message: dict):
+        ies = []
+        for ie in message['ies']:
+            if ie_name in ie:
+                ies.append(ie)
+        return ies

--- a/lib/gsup/protocol/ipa_peer.py
+++ b/lib/gsup/protocol/ipa_peer.py
@@ -1,0 +1,71 @@
+"""
+    PyHSS IP Access Peer - Represents a peer in the IPA protocol
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from asyncio import StreamReader, StreamWriter
+from enum import IntEnum
+
+
+class IPAPeerRole(IntEnum):
+    SGSN = 0
+    MSC = 1
+
+
+class IPAPeer:
+    SUPPORTED_IPA_TAGS = list(
+        ['SERNR', 'UNITNAME', 'LOCATION', 'TYPE', 'EQUIPVERS', 'SWVERSION', 'IPADDR', 'MACADDR', 'UNIT'])
+    _PRIMARY_ID_PREFERENCE = list(['MACADDR', 'UNIT'])
+    _ROLE_PREFERENCE_TAGS = list(['TYPE', 'UNIT', 'UNITNAME'])
+
+    def __init__(self, name: str, tags: dict, reader: StreamReader, writer: StreamWriter):
+        self.name = name
+        self.tags = tags
+        self.primary_id = None
+        self.role = None
+        self.reader = reader
+        self.writer = writer
+
+        # Resolve the primary ID by preference
+        for tag in self._PRIMARY_ID_PREFERENCE:
+            if tag in tags:
+                self.primary_id = tags[tag]
+                break
+
+        if self.primary_id is None:
+            raise ValueError(
+                "No primary ID found in the tags. Need at least one of: " + ', '.join(self._PRIMARY_ID_PREFERENCE))
+
+        # Resolve role by tags
+        for tag in self._ROLE_PREFERENCE_TAGS:
+            if tag in tags:
+                tag_val = tags[tag]
+                if IPAPeerRole.MSC.name.lower() in tag_val.lower():
+                    self.role = IPAPeerRole.MSC
+                    break
+                elif IPAPeerRole.SGSN.name.lower() in tag_val.lower():
+                    self.role = IPAPeerRole.SGSN
+                    break
+
+        if self.role is None:
+            raise ValueError(
+                "Role not found in tags. 'sgsn' or 'msc' must appear in one of there tags: " + ', '.join(
+                    self._ROLE_PREFERENCE_TAGS))
+    def __str__(self):
+        return f"[{self.name} ({self.role.name})]"

--- a/lib/gsup/protocol/osmocom_ipa.py
+++ b/lib/gsup/protocol/osmocom_ipa.py
@@ -1,0 +1,253 @@
+"""
+/*
+ * This file was copied & modified from
+ * https://github.com/osmocom/python_osmo-python-tests/blob/master/osmopy/twisted_ipa.py
+ *
+ * Copyright (C) 2016-2018 sysmocom s.f.m.c. GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+"""
+
+import struct
+
+class IPAError(RuntimeError):
+    pass
+class IPAUnknownTag(IPAError):
+    pass
+
+class IPA(object):
+    """
+    Stateless IPA protocol multiplexer: add/remove/parse (extended) header
+    """
+    version = "0.0.7"
+    TCP_PORT_OML = 3002
+    TCP_PORT_RSL = 3003
+    # OpenBSC extensions: OSMO, MGCP_OLD
+    PROTO = dict(RSL=0x00, CCM=0xFE, SCCP=0xFD, OML=0xFF, OSMO=0xEE, MGCP_OLD=0xFC)
+    # ...OML Router Control, GSUP GPRS extension, Osmocom Authn Protocol
+    EXT = dict(CTRL=0, MGCP=1, LAC=2, SMSC=3, ORC=4, GSUP=5, OAP=6, RSPRO=7)
+    # OpenBSC extension: SCCP_OLD
+    MSGT = dict(PING=0x00, PONG=0x01, ID_GET=0x04, ID_RESP=0x05, ID_ACK=0x06, SCCP_OLD=0xFF)
+    _IDTAG = dict(SERNR=0, UNITNAME=1, LOCATION=2, TYPE=3, EQUIPVERS=4, SWVERSION=5, IPADDR=6, MACADDR=7, UNIT=8)
+    CTRL_GET = 'GET'
+    CTRL_SET = 'SET'
+    CTRL_REP = 'REPLY'
+    CTRL_ERR = 'ERROR'
+    CTRL_TRAP = 'TRAP'
+    CTRL_TRAP_ID = 0
+
+    @staticmethod
+    def _l(d, p):
+        """
+        Reverse dictionary lookup: return key for a given value
+        """
+        if p is None:
+            return 'UNKNOWN'
+        return list(d.keys())[list(d.values()).index(p)]
+
+    @staticmethod
+    def _tag(t, v):
+        """
+        Create TAG as TLV data
+        """
+        return struct.pack(">HB", len(v) + 1, t) + v
+
+    def proto(self, p):
+        """
+        Lookup protocol name
+        """
+        return self._l(self.PROTO, p)
+
+    def ext(self, p):
+        """
+        Lookup protocol extension name
+        """
+        return self._l(self.EXT, p)
+
+    def msgt(self, p):
+        """
+        Lookup message type name
+        """
+        return self._l(self.MSGT, p)
+
+    def idtag(self, p):
+        """
+        Lookup ID tag name
+        """
+        return self._l(self._IDTAG, p)
+
+    def ext_name(self, proto, exten):
+        """
+        Return proper extension byte name depending on the protocol used
+        """
+        if self.PROTO['CCM'] == proto:
+            return self.msgt(exten)
+        if self.PROTO['OSMO'] == proto:
+            return self.ext(exten)
+        return None
+
+    @staticmethod
+    def add_header(data, proto, ext=None):
+        """
+        Add IPA header (with extension if necessary), data must be represented as bytes
+        """
+        if ext is None:
+            return struct.pack(">HB", len(data) + 1, proto) + data
+        return struct.pack(">HBB", len(data) + 1, proto, ext) + data
+
+    def del_header(self, data):
+        """
+        Strip IPA protocol header correctly removing extension if present
+        Returns data length, IPA protocol, extension (or None if not defined for a give protocol) and the data without header
+        """
+        if data is None or len(data) == 0:
+            return None, None, None, None
+
+        (dlen, proto) = struct.unpack('>HB', data[:3])
+        if self.PROTO['OSMO'] == proto or self.PROTO['CCM'] == proto:  # there's extension which we have to unpack
+            return struct.unpack('>HBB', data[:4]) + (data[4:],)  # length, protocol, extension, data
+        return dlen, proto, None, data[3:]  # length, protocol, _, data
+
+    def skip_traps(self, data):
+        """
+        Take one or more ctrl messages and data and return first non-TRAP message or None
+        """
+        if data is None or len(data) == 0:
+            return None
+
+        (head, tail) = self.split_combined(data)
+        (length, _, _, payload) = self.del_header(head)
+        # skip over broken messages as well as TRAPs
+        if length == 0 or payload[:(length + 3)].decode('utf-8').startswith(self.CTRL_TRAP):
+            return self.skip_traps(tail)
+
+        return head
+
+    def split_combined(self, data):
+        """
+        Split the data which contains multiple concatenated IPA messages into tuple (first, rest) where 'rest' contains
+        remaining messages and 'first' is the single IPA message. No headers are stripped in 'first' or 'rest'.
+        """
+        if data is None or len(data) == 0:
+            return None, None
+
+        (length, _, _, _) = self.del_header(data)
+        return data[:(length + 3)], data[(length + 3):]
+
+    def tag_serial(self, data):
+        """
+        Make TAG for serial number
+        """
+        return self._tag(self._IDTAG['SERNR'], data)
+
+    def tag_name(self, data):
+        """
+        Make TAG for unit name
+        """
+        return self._tag(self._IDTAG['UNITNAME'], data)
+
+    def tag_loc(self, data):
+        """
+        Make TAG for location
+        """
+        return self._tag(self._IDTAG['LOCATION'], data)
+
+    def tag_type(self, data):
+        """
+        Make TAG for unit type
+        """
+        return self._tag(self._IDTAG['TYPE'], data)
+
+    def tag_equip(self, data):
+        """
+        Make TAG for equipment version
+        """
+        return self._tag(self._IDTAG['EQUIPVERS'], data)
+
+    def tag_sw(self, data):
+        """
+        Make TAG for software version
+        """
+        return self._tag(self._IDTAG['SWVERSION'], data)
+
+    def tag_ip(self, data):
+        """
+        Make TAG for IP address
+        """
+        return self._tag(self._IDTAG['IPADDR'], data)
+
+    def tag_mac(self, data):
+        """
+        Make TAG for MAC address
+        """
+        return self._tag(self._IDTAG['MACADDR'], data)
+
+    def tag_unit(self, data):
+        """
+        Make TAG for unit ID
+        """
+        return self._tag(self._IDTAG['UNIT'], data)
+
+    def identity(self, unit=b'', mac=b'', location=b'', utype=b'', equip=b'', sw=b'', name=b'', serial=b''):
+        """
+        Make IPA IDENTITY tag list, by default returns empty concatenated bytes of tag list
+        """
+        return self.tag_unit(unit) + self.tag_mac(mac) + self.tag_loc(location) + self.tag_type(utype) + self.tag_equip(
+            equip) + self.tag_sw(sw) + self.tag_name(name) + self.tag_serial(serial)
+
+    def req_identity(self, id_tags=None):
+        """
+        Make IPA IDENTITY tag list, by default returns empty concatenated bytes of tag list
+        """
+        encoded = bytearray()
+        if id_tags is None:
+            id_tags = ['UNIT', 'MACADDR', 'TYPE', 'SWVERSION', 'LOCATION', 'UNITNAME']
+
+        for tag in id_tags:
+            if tag not in self._IDTAG:
+                raise IPAUnknownTag(f"Unknown Tag given {tag}")
+            encoded += bytearray([0x01, self._IDTAG[tag]])
+
+        return encoded
+
+    def ping(self):
+        """
+        Make PING message
+        """
+        return self.add_header(b'', self.PROTO['CCM'], self.MSGT['PING'])
+
+    def pong(self):
+        """
+        Make PONG message
+        """
+        return self.add_header(b'', self.PROTO['CCM'], self.MSGT['PONG'])
+
+    def id_ack(self):
+        """
+        Make ID_ACK CCM message
+        """
+        return self.add_header(b'', self.PROTO['CCM'], self.MSGT['ID_ACK'])
+
+    def id_get(self):
+        """
+        Make ID_GET CCM message
+        """
+        return self.add_header(self.req_identity(), self.PROTO['CCM'], self.MSGT['ID_GET'])
+
+    def id_resp(self, data):
+        """
+        Make ID_RESP CCM message
+        """
+        return self.add_header(data, self.PROTO['CCM'], self.MSGT['ID_RESP'])

--- a/lib/gsup/request_dispatcher.py
+++ b/lib/gsup/request_dispatcher.py
@@ -1,0 +1,102 @@
+"""
+    PyHSS GSUP Request dispatcher
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from typing import Dict
+
+from osmocom.gsup.message import GsupMessage, MsgType
+
+from database import Database
+from gsup.controller.abstract_controller import GsupController
+from gsup.controller.air import AIRController
+from gsup.controller.isr import ISRController
+from gsup.controller.noop import NoopController
+from gsup.controller.pur import PURController
+from gsup.controller.ulr import ULRTransaction, ULRController
+from gsup.protocol.gsup_msg import GsupMessageBuilder, GsupMessageUtil
+from gsup.protocol.ipa_peer import IPAPeer
+from gsup.protocol.osmocom_ipa import IPA
+from logtool import LogTool
+
+
+class GsupRequestDispatcher:
+    def __init__(self, logger: LogTool, database: Database, all_peers: Dict[str, IPAPeer]):
+        self.__ulr_transactions: Dict[str, ULRTransaction] = dict()
+        self.logger = logger
+        self.database = database
+        self.ipa = IPA()
+        self.controller_mapping: Dict[MsgType, GsupController] = {
+                MsgType.SEND_AUTH_INFO_REQUEST: AIRController(logger, database),
+                MsgType.UPDATE_LOCATION_REQUEST: ULRController(logger, database, self.__ulr_transactions, all_peers),
+                MsgType.INSERT_DATA_RESULT: ISRController(logger, database, self.__ulr_transactions),
+                MsgType.INSERT_DATA_ERROR: ISRController(logger, database, self.__ulr_transactions),
+                MsgType.LOCATION_CANCEL_RESULT: NoopController(logger, database),
+                MsgType.LOCATION_CANCEL_ERROR: NoopController(logger, database),
+                MsgType.AUTH_FAIL_REPORT: NoopController(logger, database),
+                MsgType.PURGE_MS_REQUEST: PURController(logger, database),
+        }
+
+
+    async def dispatch(self, peer: IPAPeer, request: GsupMessage):
+        # clean up old transactions
+        transactions_to_remove = []
+        for peer_name in list(self.__ulr_transactions.keys()):
+            if self.__ulr_transactions[peer_name].is_finished():
+                transactions_to_remove.append(peer_name)
+
+        for peer_name in transactions_to_remove:
+            del self.__ulr_transactions[peer_name]
+
+        if request.msg_type in self.controller_mapping:
+            await self.controller_mapping[request.msg_type].handle_message(peer, request)
+            return
+
+        await self.__handle_gsup_unhandled_request(peer, request)
+
+    async def __send_gsup_response(self, peer: IPAPeer, response: GsupMessage):
+        data = response.to_bytes()
+        IPA.add_header(data, self.ipa.PROTO['OSMO'], self.ipa.EXT['GSUP'])
+        peer.writer.write(data)
+        await peer.writer.drain()
+
+    async def __handle_gsup_unhandled_request(self, peer: IPAPeer, gsup: GsupMessage):
+        error_responses = {
+            MsgType.CHECK_IMEI_REQUEST: MsgType.CHECK_IMEI_ERROR,
+            MsgType.DELETE_DATA_REQUEST: MsgType.DELETE_DATA_ERROR,
+            MsgType.EPDG_TUNNEL_REQUEST: MsgType.EPDG_TUNNEL_ERROR,
+            MsgType.LOCATION_CANCEL_REQUEST: MsgType.LOCATION_CANCEL_ERROR,
+            MsgType.MO_FORWARD_SM_REQUEST: MsgType.MO_FORWARD_SM_ERROR,
+            MsgType.MT_FORWARD_SM_REQUEST: MsgType.MT_FORWARD_SM_ERROR,
+            MsgType.PROC_SS_REQUEST: MsgType.PROC_SS_ERROR,
+            MsgType.READY_FOR_SM_REQUEST: MsgType.READY_FOR_SM_ERROR,
+        }
+
+        if gsup.msg_type in error_responses:
+            builder = GsupMessageBuilder().with_msg_type(error_responses[gsup.msg_type])
+            imsi = GsupMessageUtil.get_first_ie_by_name('imsi', gsup.to_dict())
+            if imsi:
+                builder.with_ie('imsi', imsi)
+            await self.logger.logAsync(service='GSUP', level='WARN',
+                                       message=f"Unhandled GSUP message {gsup.msg_type} from {peer}. Responding with error.")
+            await self.__send_gsup_response(peer, builder)
+            return
+
+        raise ValueError(
+            f"Unhandled GSUP message {gsup.msg_type} from {peer} to which I don't know how to respond. Closing connection.")

--- a/lib/gsup/server.py
+++ b/lib/gsup/server.py
@@ -1,0 +1,218 @@
+"""
+    PyHSS GSUP Server
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import asyncio
+import traceback
+from asyncio import StreamReader, StreamWriter
+from typing import Dict, List
+
+from osmocom.gsup.message import GsupMessage
+
+from banners import Banners
+from database import Database
+from gsup.protocol.ipa_peer import IPAPeer
+from gsup.protocol.osmocom_ipa import IPA
+from gsup.request_dispatcher import GsupRequestDispatcher
+from logtool import LogTool
+
+
+class GsupServer:
+    SUPPORTED_IPA_PROTOCOLS = list(['CCM', 'OSMO'])
+    SUPPORTED_IPA_EXTENSIONS = list(['GSUP'])
+    SUPPORTED_IPA_MSGTS = list(['PING', 'PONG', 'ID_GET', 'ID_RESP', 'ID_ACK'])
+
+    def __init__(self, host: str, port: int, socket_timeout: int, logger: LogTool):
+        self.host = host
+        self.port = port
+        self.socket_timeout = socket_timeout
+        self.logger = logger
+        self.active_connections: Dict[str, IPAPeer] = dict()
+        self.connections_pending_activation: List[str] = list()
+        self.connections_pending_pings: Dict[str, int] = dict()
+        self.ipa = IPA()
+        self.gsup_handler = GsupRequestDispatcher(logger, Database(logger), self.active_connections)
+
+    async def start_server(self):
+        server = await asyncio.start_server(self.__handle_connection, self.host, self.port)
+        self.logger.log(service='GSUP', level='INFO', message=f"{Banners().gsupService()}")
+        self.logger.log(service='GSUP', level='INFO', message=f"GSUP server started on {self.host}:{self.port}")
+        async with server:
+            await server.serve_forever()
+
+    async def __handle_connection(self, reader: StreamReader, writer: StreamWriter):
+        """
+        Handle incoming connection
+        """
+        peer_info = writer.get_extra_info('peername')
+        if peer_info is None:
+            await self.logger.logAsync(service='GSUP', level='ERROR', message="Peer information not available")
+            writer.close()
+            return
+
+        peer_name = f"{peer_info[0]}:{peer_info[1]}"
+        while True:
+            clear_connections = False
+            try:
+                if reader.at_eof():
+                    await self.logger.logAsync(service='GSUP', level='DEBUG', message="Connection closed by peer")
+                    clear_connections = True
+                    writer.close()
+                    return
+
+                if peer_name not in self.active_connections and peer_name not in self.connections_pending_activation:
+                    await self.logger.logAsync(service='GSUP', level='DEBUG',
+                                               message=f"New connection from {peer_name}.")
+                    self.connections_pending_activation.append(peer_name)
+                    writer.write(self.ipa.id_get())
+                    await writer.drain()
+
+                data = await asyncio.wait_for(reader.readexactly(3), timeout=self.socket_timeout)
+                payload_length = int.from_bytes(data[0:2], 'big')
+                try:
+                    protocol = self.ipa.proto(data[2])
+                except ValueError:
+                    raise ValueError(f"Unsupported protocol:  {data[2]:#04x}")
+                if protocol not in self.SUPPORTED_IPA_PROTOCOLS:
+                    raise ValueError(f"Unsupported protocol: {protocol}")
+
+                if protocol == 'CCM':
+                    await self.__handle_ccm(reader, writer, peer_name, payload_length)
+                    continue
+
+                if protocol == 'OSMO':
+                    peer = self.active_connections.get(peer_name)
+                    if peer is None:
+                        # This may happen if an unsupported OSMO protocol ext is received
+                        # To handle this, we create a temporary peer object.
+                        # The MSC peer tag is arbitrary and exists only to satisfy the IPAPeer constructor
+                        peer = IPAPeer(peer_name, {'UNIT': 'msc'}, reader, writer)
+                    await self.__handle_gsup(peer, payload_length)
+                    continue
+            except ValueError as e:
+                await self.logger.logAsync(service='GSUP', level='ERROR',
+                                           message=f"{peer_name}: {e}. Closing connection.")
+                writer.close()
+                clear_connections = True
+                return
+
+            except asyncio.TimeoutError:
+                await self.logger.logAsync(service='GSUP', level='ERROR',
+                                           message=f"Timeout reading data from peer: {peer_name}")
+                writer.close()
+                clear_connections = True
+                return
+
+
+            except (ConnectionResetError, asyncio.IncompleteReadError):
+                await self.logger.logAsync(service='GSUP', level='INFO',
+                                           message=f"GSUP Client disconnected: {peer_name}")
+                writer.close()
+                clear_connections = True
+                return
+
+            except Exception as e:
+                await self.logger.logAsync(service='GSUP', level='ERROR',
+                                           message=f"Error handling connection: {str(e)} trace: {traceback.format_exc()}")
+                writer.close()
+                clear_connections = True
+                return
+            finally:
+                if clear_connections:
+                    if peer_name in self.active_connections:
+                        del self.active_connections[peer_name]
+                    if peer_name in self.connections_pending_activation:
+                        self.connections_pending_activation.remove(peer_name)
+                    if peer_name in self.connections_pending_pings:
+                        del self.connections_pending_pings[peer_name]
+
+    async def __handle_ccm(self, reader: StreamReader, writer: StreamWriter, peer: str, payload_length: int):
+        data = await asyncio.wait_for(reader.readexactly(payload_length), timeout=self.socket_timeout)
+        message_type = self.ipa.msgt(data[0])
+
+        if message_type not in self.SUPPORTED_IPA_MSGTS:
+            raise ValueError(f"Unsupported message type: {message_type}")
+
+        if peer in self.connections_pending_activation and message_type == 'PING':
+            self.connections_pending_pings[peer] = self.connections_pending_pings.get(peer, 0) + 1
+            return
+
+        if peer not in self.active_connections and message_type != 'ID_RESP':
+            await self.logger.logAsync(service='GSUP', level='ERROR',
+                                       message=f"Client message received without known identity {peer}")
+            return
+
+        if message_type == 'ID_RESP' and peer not in self.connections_pending_activation:
+            await self.logger.logAsync(service='GSUP', level='ERROR',
+                                       message=f"Received ID_RESP from {peer} without pending activation")
+            raise ValueError("Received ID_RESP from peer without pending activation")
+
+        if message_type == 'ID_RESP':
+            await self.__handle_ccm_identity_response(reader, writer, peer, data[1:])
+            return
+
+        if message_type == 'PING':
+            await self.logger.logAsync(service='GSUP', level='DEBUG', message="Received PING message")
+            writer.write(self.ipa.pong())
+            await writer.drain()
+            return
+
+        await self.logger.logAsync(service='GSUP', level='WARN', message=f"Unimplemented message type: {message_type}")
+
+    async def __handle_ccm_identity_response(self, reader: StreamReader, writer: StreamWriter, peer_name: str,
+                                             payload: bytes):
+        tags = {}
+        index = 0
+        while index < len(payload):
+            try:
+                length = int.from_bytes(payload[index:index + 2], 'big') - 1
+                tag = self.ipa.idtag(payload[index + 2:index + 3][0])
+                value = str(payload[index + 3:index + 3 + length], 'utf-8')
+                tags[tag] = value
+                index += 3 + length
+            except Exception as e:
+                await self.logger.logAsync(service='GSUP', level='ERROR',
+                                           message=f"Error parsing ID_RESP payload: {str(e)}")
+                writer.close()
+
+        peer = IPAPeer(peer_name, tags, reader, writer)
+        self.active_connections[peer_name] = peer
+        await self.logger.logAsync(service='GSUP', level='INFO',
+                                   message=f"New peer connected: {peer}")
+        writer.write(self.ipa.id_ack())
+        self.connections_pending_activation.remove(peer_name)
+
+        if peer_name in self.connections_pending_pings:
+            for _ in range(self.connections_pending_pings[peer_name]):
+                writer.write(self.ipa.pong())
+            del self.connections_pending_pings[peer_name]
+
+        await writer.drain()
+
+    async def __handle_gsup(self, peer: IPAPeer, payload_length: int):
+        data = await asyncio.wait_for(peer.reader.readexactly(payload_length), timeout=self.socket_timeout)
+        ext = self.ipa.ext(data[0])
+        if ext not in self.SUPPORTED_IPA_EXTENSIONS:
+            raise ValueError(f"Unsupported OSMOCOM EXT protocol: {ext}")
+
+        request = GsupMessage.from_bytes(data[1:])
+        if request is None:
+            raise ValueError(f"Error parsing GSUP message from peer {peer}")
+        await self.gsup_handler.dispatch(peer, request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ prometheus_client==0.16.0
 pycryptodome==3.17
 pymongo==4.3.3
 pysctp==0.7.2
+pyosmocom==0.0.7
+comp128==1.0.0
 pysnmp==4.4.12
 PyYAML==6.0
 redis==5.0.0

--- a/services/gsupService.py
+++ b/services/gsupService.py
@@ -1,0 +1,45 @@
+"""
+    PyHSS GSUP Service
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.realpath(os.path.dirname(__file__) + "/../lib"))
+import yaml
+
+from gsup.server import GsupServer
+from logtool import LogTool
+
+if __name__ == '__main__':
+    config = None
+    try:
+        with open("../config.yaml", "r") as configFile:
+            config = yaml.safe_load(configFile)
+    except:  # noqa
+        print("Error reading configuration file")
+        exit(1)
+
+    bind_ip = config['hss']['gsup']['bind_ip']
+    bind_port = config['hss']['gsup']['bind_port']
+
+    gsup_server = GsupServer(bind_ip, bind_port, 60, LogTool(config))
+    asyncio.run(gsup_server.start_server())

--- a/systemd/pyhss_gsup.service
+++ b/systemd/pyhss_gsup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=PyHSS HSS Service
+PartOf=pyhss.service
+
+
+[Service]
+User=root
+WorkingDirectory=/etc/pyhss/services/
+ExecStart=python3 gsupService.py
+Restart=always
+
+[Install]
+WantedBy=pyhss.service

--- a/tests/test_gsup_air.py
+++ b/tests/test_gsup_air.py
@@ -1,0 +1,182 @@
+"""
+    PyHSS GSUP Client for testing
+
+    This file is not really a unit test, but a client that connects to the GSUP server
+    It helped during the development of the GSUP server to test the messages and
+    this file has been left here in the hope that it may be useful.
+
+    Copyright (C) 2025  Lennart Rosam <hello@takuto.de>
+    Copyright (C) 2025  Alexander Couzens <lynxis@fe80.eu>
+
+    SPDX-License-Identifier: AGPL-3.0-or-later
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import socket
+
+from osmocom.gsup.message import MsgType, GsupMessage
+
+from gsup.protocol.gsup_msg import GsupMessageBuilder, GsupMessageUtil
+from gsup.protocol.osmocom_ipa import IPA
+
+
+
+class GSUPClient:
+    def __init__(self, server_ip, server_port, identity='SGSN'):
+        self.server_ip = server_ip
+        self.server_port = server_port
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.ipa = IPA()
+        self.identity = identity
+
+    def connect(self):
+        self.sock.connect((self.server_ip, self.server_port))
+
+        # Receive the identity request from server
+        identity = self.sock.recv(3)
+        payload_length = int.from_bytes(identity[0:2], 'big')
+        protocol = self.ipa.proto(identity[2])
+
+        if protocol != 'CCM':
+            socket.close()
+            raise ValueError(f"Unsupported protocol: {protocol}")
+
+        payload = self.sock.recv(payload_length)
+        msg_type = self.ipa.msgt(payload[0])
+
+        if msg_type != 'ID_GET':
+            socket.close()
+            raise ValueError(f"Unsupported message type: {msg_type}")
+
+        # Send the identity response to the server
+        data = self.ipa.tag_unit(self.identity.encode('utf-8'))
+        data = self.ipa.id_resp(data)
+        self.sock.send(data)
+
+        # Check if server acked the identity response
+        ack_hdr = self.sock.recv(3)
+        payload_length = int.from_bytes(identity[0:2], 'big')
+        protocol = self.ipa.proto(identity[2])
+        if protocol != 'CCM':
+            self.sock.close()
+            raise ValueError(f"Unsupported protocol: {protocol}")
+
+        ack = self.sock.recv(payload_length)
+        msg_type = self.ipa.msgt(ack[0])
+        if msg_type != 'ID_ACK':
+            self.sock.close()
+            raise ValueError(f"Unexpected ACK message: {msg_type}")
+
+    def send_auth_info_request(self, imsi):
+        request = (GsupMessageBuilder()
+         .with_msg_type(MsgType.SEND_AUTH_INFO_REQUEST)
+         .with_ie('imsi', imsi)
+         .with_ie('cn_domain', 'ps')
+         ).build()
+
+        data = self.ipa.add_header(request.to_bytes(), self.ipa.PROTO['OSMO'], self.ipa.EXT['GSUP'])
+        self.sock.send(data)
+
+        response = self.__read_response()
+
+        print(f"Received response: {response.to_dict()}")
+
+    def send_ulr_request(self, imsi):
+        request = (GsupMessageBuilder()
+         .with_msg_type(MsgType.UPDATE_LOCATION_REQUEST)
+         .with_ie('imsi', imsi)
+         .with_ie('cn_domain', 'ps')
+        ).build()
+
+        data = self.ipa.add_header(request.to_bytes(), self.ipa.PROTO['OSMO'], self.ipa.EXT['GSUP'])
+        self.sock.send(data)
+
+        response = self.__read_response()
+        print(f"Received response: {response.to_dict()}")
+
+        if response.msg_type != MsgType.INSERT_DATA_REQUEST:
+            print(f"Received error response: {response.msg_type()}")
+            return
+
+        # Send the insert data response
+        insert_data_resp = (GsupMessageBuilder()
+         .with_msg_type(MsgType.INSERT_DATA_RESULT)
+         .with_ie('imsi', imsi)
+         .with_ie('cn_domain', 'ps')
+        ).build()
+
+        data = self.ipa.add_header(insert_data_resp.to_bytes(), self.ipa.PROTO['OSMO'], self.ipa.EXT['GSUP'])
+        self.sock.send(data)
+
+        response = self.__read_response()
+        print(f"Received response: {response.to_dict()}")
+
+    def wait_for_location_cancel(self):
+        response = self.__read_response()
+        print(f"Received response: {response.to_dict()}")
+
+        if response.msg_type != MsgType.LOCATION_CANCEL_REQUEST:
+            print(f"Received error response: {response.msg_type()}")
+            return
+
+        # Send the location cancel response
+        cancel_resp = (GsupMessageBuilder()
+         .with_msg_type(MsgType.LOCATION_CANCEL_RESULT)
+         .with_ie('imsi', GsupMessageUtil.get_first_ie_by_name('imsi', response.to_dict()))
+        ).build()
+
+        data = self.ipa.add_header(cancel_resp.to_bytes(), self.ipa.PROTO['OSMO'], self.ipa.EXT['GSUP'])
+        self.sock.send(data)
+
+    def send_purge_ue(self, imsi):
+        request = (GsupMessageBuilder()
+         .with_msg_type(MsgType.PURGE_MS_REQUEST)
+         .with_ie('imsi', imsi)
+        ).build()
+
+        data = self.ipa.add_header(request.to_bytes(), self.ipa.PROTO['OSMO'], self.ipa.EXT['GSUP'])
+        self.sock.send(data)
+
+        response = self.__read_response()
+        print(f"Received response: {response.to_dict()}")
+
+    def __read_response(self) -> GsupMessage:
+        resp_hdr = self.sock.recv(3)
+        payload_length = int.from_bytes(resp_hdr[0:2], 'big')
+        payload = self.sock.recv(payload_length)
+        response = GsupMessage.from_bytes(payload[1:])
+        return response
+
+
+    def disconnect(self):
+        self.sock.close()
+
+
+
+if __name__ == '__main__':
+    client = GSUPClient('127.0.0.1', 4222, 'SGSN-NG')
+    client2 = GSUPClient('127.0.0.1', 4222, 'SGSN')
+
+    client.connect()
+    client2.connect()
+
+    client.send_auth_info_request('262423403000001')
+    client.send_ulr_request('262423403000001')
+
+    #client2.wait_for_location_cancel()
+    client.send_purge_ue('262423403000001')
+
+    client.disconnect()
+    client2.disconnect()

--- a/tests/test_milenage.py
+++ b/tests/test_milenage.py
@@ -1,0 +1,19 @@
+import binascii
+from unittest import TestCase
+
+from milenage import Milenage
+
+
+class MilenageTest(TestCase):
+    def test_milenage_f2(self):
+        # GIVEN
+        expected_res = "5b510215e92efc47"
+        ki = binascii.unhexlify("937EEEE6CE2C65D066DDE32BA79967ED")
+        op_c = binascii.unhexlify("F4953DF2C4544E929CB5CFB3880E0AF8")
+        rand = binascii.unhexlify("fe328a60e7108543f86f845884b842f8")
+
+        # WHEN
+        res = Milenage.f2(ki, rand, op_c)
+
+        # THEN
+        self.assertEqual(expected_res, res.hex())


### PR DESCRIPTION
Osmocom's GSUP is a minimalistic protocol that is used by their 2G components (OsmoMSC, OsmoSGSN) in place of MAP/TCAP as it is a lot simpler.

Find more information about GSUP [here][1].

At [C3GSM][2], we are operating our own 2G/3G/4G networks during Chaos Computer Club events like the recent 38C3 conference. Currently, the 4G network is integrated using a Diameter to GSUP protocol proxy, that allows us to use OsmoHLR for 4G, but the only implemented procedures are for Authentication and UpdateLocation.

In order to facilitate IMS / VoLTE / VoWifi in the future, it would be convenient to replace OsmoHLR with PyHSS but also retain the 2G/3G stack of OsmoSGSN and OsmoMSC. Therefore, we implemented the GSUP protocol and 2G/3G procedures into PyHSS, enabling an open source 2G/3G/4G network with one central brain.

Implemented procedures are:

- sendAuthInfo
- updateLocation
- insertSubscriber
- cancelLocation
- purgeMS

This implementation is working and has been tested during 38C3. We'd like to contribute our changes back upstream as this might help other people to also run their own 2G/3G/4G combined networks and use Osmocom for their 2G/3G needs.

[1]: https://ftp.osmocom.org/docs/osmo-hlr/master/osmohlr-usermanual.pdf
[2]: https://c3gsm.de/