### PR TITLE
lib/milenage: use Cryptodome instead of Crypto

### DIFF
--- a/lib/milenage.py
+++ b/lib/milenage.py
@@ -8,8 +8,8 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 import hmac
-from Crypto.Cipher import AES
-from Crypto.Random import random
+from Cryptodome.Cipher import AES
+from Cryptodome.Random import random
 
 from lte import BaseLTEAuthAlgo
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask_restx==1.1.0
 Jinja2==3.1.2
 mongo==0.2.0
 prometheus_client==0.16.0
-pycryptodome==3.17
+pycryptodomex==3.17
 pymongo==4.3.3
 pysctp==0.7.2
 pysnmp==4.4.12


### PR DESCRIPTION
PyCryptodome modules are available in Crypto for legacy compatibility with the old PyCrypto library, and in Cryptodome. Switch to the non-legacy name, so the Debian 12 package python3-pycryptodome can be used (there is no python3-pycrypto package in Debian anymore).

See also:
* https://github.com/Legrandin/pycryptodome/?tab=readme-ov-file#pycryptodome
* https://packages.debian.org/bookworm/amd64/python3-pycryptodome/filelist