### PR TITLE
Use pydantic instead of pydantic_core

### DIFF
--- a/lib/diameter.py
+++ b/lib/diameter.py
@@ -19,7 +19,7 @@ import requests
 import traceback
 import re
 from baseModels import Peer, OutboundData
-import pydantic_core
+import pydantic
 import xml.etree.ElementTree as ET
 
 class Diameter:
@@ -736,7 +736,7 @@ class Diameter:
                 return filteredConnectedPeers
             
             for peerKey, peer in activePeers.items():
-                diameterPeer = Peer.model_validate(pydantic_core.from_json(json.dumps(peer)))
+                diameterPeer = Peer.model_validate(pydantic.from_json(json.dumps(peer)))
                 diameterPeerType = None
                 if diameterPeer.Metadata:
                     metadataJson = json.loads(diameterPeer.Metadata)
@@ -770,7 +770,7 @@ class Diameter:
                 return filteredConnectedPeers
             
             for peerKey, peer in activePeers.items():
-                diameterPeer = Peer.model_validate(pydantic_core.from_json(json.dumps(peer)))
+                diameterPeer = Peer.model_validate(pydantic.from_json(json.dumps(peer)))
                 diameterPeerType = None
                 if diameterPeer.Metadata:
                     metadataJson = json.loads(diameterPeer.Metadata)
@@ -814,7 +814,7 @@ class Diameter:
                 return {}
 
             for peerKey, peer in activePeers.items():
-                diameterPeer = Peer.model_validate(pydantic_core.from_json(json.dumps(peer)))
+                diameterPeer = Peer.model_validate(pydantic.from_json(json.dumps(peer)))
                 if diameterPeer.Hostname.lower() == hostname and diameterPeer.Connected:
                     return diameterPeer
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ Werkzeug==2.2.3
 mysqlclient
 prometheus_flask_exporter
 pydantic==2.8.2
-pydantic_core==2.20.1
 tzlocal==4.3
 influxdb==5.3.1
 xmltodict==0.14.2

--- a/services/diameterService.py
+++ b/services/diameterService.py
@@ -10,7 +10,7 @@ from diameterAsync import DiameterAsync
 from banners import Banners
 from logtool import LogTool
 from baseModels import Peer, InboundData, OutboundData
-import pydantic_core
+import pydantic
 import traceback
 
 class DiameterService:
@@ -310,7 +310,7 @@ class DiameterService:
             try:
                 await(self.logTool.logAsync(service='Diameter', level='debug', message=f"[Diameter] [writeOutboundData] [{coroutineUuid}] Waiting for messages for host {clientAddress} on port {clientPort}"))
                 pendingOutboundMessage = (await(self.redisWriterMessaging.awaitMessage(key=f"diameter-outbound-{clientAddress}-{clientPort}", usePrefix=True, prefixHostname=self.hostname, prefixServiceName='diameter')))[1]
-                outboundData = OutboundData.model_validate(pydantic_core.from_json(pendingOutboundMessage))
+                outboundData = OutboundData.model_validate(pydantic.from_json(pendingOutboundMessage))
                 diameterOutboundBinary = bytes.fromhex(outboundData.OutboundHex)
                 await(self.logTool.logAsync(service='Diameter', level='debug', message=f"[Diameter] [writeOutboundData] [{coroutineUuid}] Sending: {diameterOutboundBinary.hex()} to to {clientAddress} on {clientPort}."))
 

--- a/services/hssService.py
+++ b/services/hssService.py
@@ -5,7 +5,7 @@ from diameter import Diameter
 from banners import Banners
 from logtool import LogTool
 from baseModels import Peer, InboundData, OutboundData
-import pydantic_core
+import pydantic
 
 
 class HssService:
@@ -52,7 +52,7 @@ class HssService:
                 for inboundMessage in inboundMessageList[1]:
                     self.logTool.log(service='HSS', level='debug', message=f"[HSS] [handleQueue] Message: {inboundMessage}", redisClient=self.redisMessaging)
                     inboundMessage = inboundMessage.decode('ascii')
-                    inboundData = InboundData.model_validate(pydantic_core.from_json(inboundMessage))
+                    inboundData = InboundData.model_validate(pydantic.from_json(inboundMessage))
                     inboundBinary = bytes.fromhex(inboundData.InboundHex)
 
                     if inboundBinary == None:
@@ -69,7 +69,7 @@ class HssService:
                             diameterPeers = self.redisMessaging.getAllHashData(self.diameterPeerKey, usePrefix=True, prefixHostname=self.hostname, prefixServiceName='diameter')
                             if diameterPeers:
                                 for diameterPeerKey, diameterPeerValue in diameterPeers.items():
-                                    diameterPeer = Peer.model_validate(pydantic_core.from_json(json.dumps(diameterPeerValue)))
+                                    diameterPeer = Peer.model_validate(pydantic.from_json(json.dumps(diameterPeerValue)))
                                     # If this is a message from a stored peer, increment prom_diam_request_count_host by 1.
                                     if diameterPeer.IpAddress == inboundData.SenderIp and diameterPeer.Port == inboundData.SenderPort:
                                         self.redisMessaging.sendMetric(serviceName='diameter', metricName='prom_diam_request_count_host',
@@ -128,7 +128,7 @@ class HssService:
                             diameterPeers = self.redisMessaging.getAllHashData(self.diameterPeerKey, usePrefix=True, prefixHostname=self.hostname, prefixServiceName='diameter')
                             if diameterPeers:
                                 for diameterPeerKey, diameterPeerValue in diameterPeers.items():
-                                    diameterPeer = Peer.model_validate(pydantic_core.from_json(json.dumps(diameterPeerValue)))
+                                    diameterPeer = Peer.model_validate(pydantic.from_json(json.dumps(diameterPeerValue)))
                                     if diameterPeer.IpAddress == inboundData.SenderIp and diameterPeer.Port == inboundData.SenderPort:
                                         self.redisMessaging.sendMetric(serviceName='diameter', metricName='prom_diam_response_count_host',
                                                     metricType='gauge', metricAction='inc',


### PR DESCRIPTION
Replace pydantic_core with pydantic, as _core should not be used directly:

> NOTE: You should not need to use pydantic-core directly; instead, use
> pydantic, which in turn uses pydantic-core.

With this change, pydantic is still in requirements.txt, and it pulls in pydantic-core via its dependencies.

Besides the fact that this is how it is supposed to be used, this also allows using the older python3-pydantic from debian 12.

Related: https://github.com/pydantic/pydantic/blob/6433ea747d86f2b8074a27ab68e4cc6e573ae92f/pyproject.toml#L49
Related: https://github.com/pydantic/pydantic-core?tab=readme-ov-file#example-of-direct-usage