### PR TITLE
Subscription-Id is 0..* according to 3GPP TS 29.212

### DIFF
--- a/lib/diameter.py
+++ b/lib/diameter.py
@@ -2537,13 +2537,18 @@ class Diameter:
                 self.logTool.log(service='HSS', level='error', message=f"[diameter.py] [Answer_16777238_272] [CCA] Error generating SOS CCA: {traceback.format_exc()}", redisClient=self.redisMessaging)
 
             #Get Subscriber info from Subscription ID
+            imsi = ""
             for SubscriptionIdentifier in self.get_avp_data(avps, 443):
+                subscription_type = -1
                 for UniqueSubscriptionIdentifier in SubscriptionIdentifier:
                     self.logTool.log(service='HSS', level='debug', message="[diameter.py] [Answer_16777238_272] [CCA] Evaluating UniqueSubscriptionIdentifier AVP " + str(UniqueSubscriptionIdentifier) + " to find IMSI", redisClient=self.redisMessaging)
+                    if UniqueSubscriptionIdentifier['avp_code'] == 450:                    
+                        subscription_type = int(UniqueSubscriptionIdentifier['misc_data'])
+                        self.logTool.log(service='HSS', level='debug', message="[diameter.py] [Answer_16777238_272] [CCA] Subscription-Type " + str(subscription_type), redisClient=self.redisMessaging)
                     if UniqueSubscriptionIdentifier['avp_code'] == 444:
-                        imsi = binascii.unhexlify(UniqueSubscriptionIdentifier['misc_data']).decode('utf-8')
-                        self.logTool.log(service='HSS', level='debug', message="[diameter.py] [Answer_16777238_272] [CCA] Found IMSI " + str(imsi), redisClient=self.redisMessaging)
-
+                        if subscription_type == 1:
+                            imsi = binascii.unhexlify(UniqueSubscriptionIdentifier['misc_data']).decode('utf-8')
+                            self.logTool.log(service='HSS', level='debug', message="[diameter.py] [Answer_16777238_272] [CCA] Found IMSI " + str(imsi), redisClient=self.redisMessaging)
             self.logTool.log(service='HSS', level='debug', message="[diameter.py] [Answer_16777238_272] [CCA] SubscriptionID: " + str(self.get_avp_data(avps, 443)), redisClient=self.redisMessaging)
             try:
                 self.logTool.log(service='HSS', level='debug', message="[diameter.py] [Answer_16777238_272] [CCA] Getting Get_Charging_Rules for IMSI " + str(imsi) + " using APN " + str(apn) + " from database", redisClient=self.redisMessaging)                                            #Get subscriber details


### PR DESCRIPTION
Subscription-Id is 0..* according to 3GPP TS 29.212 and may include other types than IMSI, thus we need to look just for type END_USER_IMSI.

For example, Open5GS sends IMSI AND End-User-E164:

AVP: Subscription-Id(443) l=44 f=-M-
    AVP Code: 443 Subscription-Id
    AVP Flags: 0x40, Mandatory: Set
    AVP Length: 44
    Subscription-Id: 000001c24000000c00000001000001bc4000001730303130313030323130333131363000
        AVP: Subscription-Id-Type(450) l=12 f=-M- val=END_USER_IMSI (1)
        AVP: Subscription-Id-Data(444) l=23 f=-M- val=001010021031160
AVP: Subscription-Id(443) l=40 f=-M-
    AVP Code: 443 Subscription-Id
    AVP Flags: 0x40, Mandatory: Set
    AVP Length: 40
    Subscription-Id: 000001c24000000c00000000000001bc40000014343931373932303231323434
        AVP: Subscription-Id-Type(450) l=12 f=-M- val=END_USER_E164 (0)
        AVP: Subscription-Id-Data(444) l=20 f=-M- val=491792021244

This caused the lookup to fail on Gx and the PCRF replied with 5030.