### PR TITLE
[Minor] Fix PCRF-CCR diameter client request.

### DIFF
--- a/lib/diameter.py
+++ b/lib/diameter.py
@@ -4785,7 +4785,6 @@ class Diameter:
         avp += self.generate_avp(296, 40, self.OriginRealm)                                              #Origin Realm
         avp += self.generate_avp(283, 40, self.string_to_hex(destinationRealm))                          #Destination Realm
         # avp += self.generate_avp(293, 40, self.string_to_hex(destinationHost))                         #Destination Host
-
         
         avp += self.generate_avp(258, 40, format(int(16777238),"x").zfill(8))   #Auth-Application-ID Gx
 

--- a/lib/diameter.py
+++ b/lib/diameter.py
@@ -4783,6 +4783,9 @@ class Diameter:
         avp += self.generate_avp(277, 40, "00000001")                                                    #Auth-Session-State (Not maintained)        
         avp += self.generate_avp(264, 40, self.OriginHost)                                               #Origin Host
         avp += self.generate_avp(296, 40, self.OriginRealm)                                              #Origin Realm
+        avp += self.generate_avp(283, 40, self.string_to_hex(destinationRealm))                          #Destination Realm
+        # avp += self.generate_avp(293, 40, self.string_to_hex(destinationHost))                         #Destination Host
+
         
         avp += self.generate_avp(258, 40, format(int(16777238),"x").zfill(8))   #Auth-Application-ID Gx
 

--- a/tools/Diameter_client.py
+++ b/tools/Diameter_client.py
@@ -184,7 +184,7 @@ while True:
         imsi = str(input("IMSI:\t"))
         apn = str(input("APN:\t"))
         ccr_type = int(input("ccr_type:\t"))
-        SendRequest(diameter.Request_16777238_272(imsi=imsi, apn=apn, ccr_type=ccr_type))
+        SendRequest(diameter.Request_16777238_272(imsi=imsi, apn=apn, ccr_type=ccr_type, destinationRealm=DestinationRealm, destinationHost=DestinationHost))
     elif request == "OCS-CCR":
         imsi = str(input("IMSI:\t"))
         ccr_type = int(input("ccr_type:\t"))


### PR DESCRIPTION
Hi! I found a small mistake in how the Request_16777238_272 function was used in the PCRF-CCR request within the Diameter client. Also, the Open5GS PCRF requires the Destination Realm AVP in the CCR Diameter (Request_16777238_272). The fix for both issues is included in the pull request. tnx!
