### PR TITLE
systemd/pyhss_gsup: set PYTHONUNBUFFERED=1

### DIFF
--- a/systemd/pyhss_gsup.service
+++ b/systemd/pyhss_gsup.service
@@ -4,6 +4,7 @@ PartOf=pyhss.service
 
 
 [Service]
+Environment="PYTHONUNBUFFERED=1"
 User=root
 WorkingDirectory=/etc/pyhss/services/
 ExecStart=python3 gsupService.py


### PR DESCRIPTION
Set this env var like in the other .service files to make log prints immediately appear in the systemd journal.