### PR TITLE
Corrected encoding of MSISDN IE

### DIFF
--- a/lib/gsup/protocol/gsup_msg.py
+++ b/lib/gsup/protocol/gsup_msg.py
@@ -52,11 +52,7 @@ class GsupMessageBuilder:
 
     def with_msisdn_ie(self, msisdn: str):
         ie = {
-            'ton_npi': {
-                'ext': False,
-                'type_of_number': 'unknown',
-                'numbering_plan_id': 'sc_specific_6'
-            },
+            'bcd_len': (len(msisdn) + 1) // 2,
             'digits': msisdn
         }
         return self.with_ie('msisdn', ie)


### PR DESCRIPTION
The coding that has been described in the osmo-hlr user manual [1] is wrong. There is no TON (type of number) not NPI (numbering plan indicator) at the beginning of the information element content.

          1   2   3   4   5   6   7   8
        +-------------------------------+
        | MSISDN IE type            |Res| octet 1
        +-------------------------------+
        | Length of IE content          | octet 2
        +-------------------------------+
        | Length of BCD content         | octet 3
        +-------------------------------+
        | Digit 1       | Digit 2       | octet 4..n
        | ....          |               |
        +-------------------------------+

The length of the BCD content specifies how many subsequent octets contain BCD data, but it does not indicate the number of digits. This length must be less than the total length of the IE content. Any octets following the BCD content shall be ignored.

This patch has been successfully tested with osmo-msc.

[1] https://downloads.osmocom.org/docs/osmo-hlr/master/osmohlr-usermanual.pdf

Related: https://projects.osmocom.org/issues/6797