### PR TITLE
Use Framed-IP-Address AVP when Subscription-Id AVP missing or can not be matched

### DIFF
--- a/lib/diameter.py
+++ b/lib/diameter.py
@@ -3611,24 +3611,22 @@ class Diameter:
                     pass
                 if identifier == None:
                     try:
-                        ueIP = subscriptionId.split('@')[1].split(':')[0]
-                        ue = self.database.Get_UE_by_IP(ueIP)
+                        ue = self.database.Get_UE_by_IP(ueIp)
                         subscriberId = ue.get('subscriber_id', None)
                         subscriberDetails = self.database.Get_Subscriber(subscriber_id=subscriberId)
                         imsi = subscriberDetails.get('imsi', None)
-                        self.logTool.log(service='HSS', level='debug', message=f"[diameter.py] [Answer_16777236_265] [AAA] Found IMSI {imsi} by IP: {ueIP}", redisClient=self.redisMessaging)
+                        self.logTool.log(service='HSS', level='debug', message=f"[diameter.py] [Answer_16777236_265] [AAA] Found IMSI {imsi} by IP: {ueIp}", redisClient=self.redisMessaging)
                     except Exception as e:
                         pass
             else:
                 imsi = None
                 msisdn = None
                 try:
-                    ueIP = self.get_avp_data(avps, 8)[0].decode('ascii') # Framed-IP-Address AVP
-                    ue = self.database.Get_UE_by_IP(ueIP)
+                    ue = self.database.Get_UE_by_IP(ueIp)
                     subscriberId = ue.get('subscriber_id', None)
                     subscriberDetails = self.database.Get_Subscriber(subscriber_id=subscriberId)
                     imsi = subscriberDetails.get('imsi', None)
-                    self.logTool.log(service='HSS', level='debug', message=f"[diameter.py] [Answer_16777236_265] [AAA] Found IMSI {imsi} by IP: {ueIP}", redisClient=self.redisMessaging)
+                    self.logTool.log(service='HSS', level='debug', message=f"[diameter.py] [Answer_16777236_265] [AAA] Found IMSI {imsi} by IP: {ueIp}", redisClient=self.redisMessaging)
                 except Exception as e:
                     pass
 


### PR DESCRIPTION
When receiving AAR without Subscription-Id AVP there was a list index out of range issues:

`[07/05/2025 14:05:57] [ERROR] [diameter.py] [Answer_16777236_265] [AAA] Error generating AAA: Traceback (most recent call last):
  File "/pyhss/lib/diameter.py", line 2891, in Answer_16777236_265
    subscriptionId = bytes.fromhex(self.get_avp_data(avps, 444)[0]).decode('ascii')
IndexError: list index out of range`

When further investigating the code I discovered that the existence of the AVP was not checked, nor that the fallback mechanism to check the UE IP was properly implemented, and was not using the already extracted/decoded Framed-IP-Address AVP.

This PR will handle the case of the Subscription-Id AVP missing and also makes sure the UE IP address is actually being used to find the PCRF session.