### PR TITLE
Avoid submitting double Diameter-Return codes

### DIFF
--- a/lib/diameter.py
+++ b/lib/diameter.py
@@ -4173,8 +4173,8 @@ class Diameter:
 
             else:
                 self.logTool.log(service='HSS', level='info', message=f"[diameter.py] [Answer_16777236_275] [STA] Unable to find serving APN for RAR, returning Result-Code 2001", redisClient=self.redisMessaging)
-
-            avp += self.generate_avp(268, 40, self.int_to_hex(2001, 4))
+                avp += self.generate_avp(268, 40, self.int_to_hex(2001, 4))
+    
             response = self.generate_diameter_packet("01", "40", 275, 16777236, packet_vars['hop-by-hop-identifier'], packet_vars['end-to-end-identifier'], avp)     #Generate Diameter packet
             return response
         except Exception as e:


### PR DESCRIPTION
In casse APN was not found for the RAR, a double response code was added to the response.