### PR TITLE
lib/S26a_crypt: fix call to comp128v3()

### DIFF
--- a/lib/S6a_crypt.py
+++ b/lib/S6a_crypt.py
@@ -147,7 +147,7 @@ def generate_2g3g_vector(key, op_c, amf, sqn, algo):
         sres, kc = crypto_obj.comp128v2(bytearray(key), rand)
     elif algo == 3:
         crypto_obj = Comp128v23()
-        sres, kc = crypto_obj.comp128v3(bytearray(key), rand, sres, kc)
+        sres, kc = crypto_obj.comp128v3(bytearray(key), rand)
 
     # Case: SIM only supports 2G Auth
     if op_c == b'':


### PR DESCRIPTION
Fix for:

```
      sres, kc = crypto_obj.comp128v3(bytearray(key), rand, sres, kc)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  TypeError: Comp128v23.comp128v3() takes 3 positional arguments but 5 were given
```

Related: https://github.com/Takuto88/comp128-python/blob/1.0.0/comp128/comp128v23.py#L95