### PR TITLE
GSUP: SAI: send correct amount of auth vectors

### DIFF
--- a/lib/gsup/protocol/gsup_msg.py
+++ b/lib/gsup/protocol/gsup_msg.py
@@ -33,18 +33,18 @@ class GsupMessageBuilder:
         self.gsup_dict['msg_type'] = msg_type.name
         return self
 
-    def with_ie(self, name: str, value):
+    def with_ie(self, name: str, value, merge: bool = True):
         if 'ies' not in self.gsup_dict:
             self.gsup_dict['ies'] = []
 
-        for ie in self.gsup_dict['ies']:
-            if name in ie and isinstance(ie[name], list) and isinstance(value, dict):
-                ie[name].append(value)
-                return self
-            elif name in ie and isinstance(ie[name], list) and isinstance(value, list):
-                ie[name].extend(value)
-                return self
-
+        if merge:
+            for ie in self.gsup_dict['ies']:
+                if name in ie and isinstance(ie[name], list) and isinstance(value, dict):
+                    ie[name].append(value)
+                    return self
+                elif name in ie and isinstance(ie[name], list) and isinstance(value, list):
+                    ie[name].extend(value)
+                    return self
 
         self.gsup_dict['ies'].append({
             name: value


### PR DESCRIPTION
Instead of having the amount of vectors hardcoded to one, implement the
same behavior as OsmoHLR: read num_vectors_req from the SAI request, and
return this amount or 5 if it is unset or higher than 5.

Add a "merge" parameter to GsupMessageBuilder.with_ie() and set it to
False for the auth_tuple IEs. This is needed, so multiple vectors are
actually in separate auth_tuple IEs, otherwise they would end up in the
same one.

With this patch, the following tests pass in the osmo-ttcn3-hacks HLR
testsuite:

* TC_gsup_sai
* TC_gsup_sai_num_auth_vectors

See details in individual commit messages.

CC: @Takuto88, @lynxis: I know you can't merge to this repository, but would you like to review this PR?