### PR TITLE
requirements.txt: upgrade SQLAlchemy to fix running with Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pysnmp==4.4.12
 PyYAML
 redis==5.0.0
 Requests==2.31.0
-SQLAlchemy==2.0.9
+SQLAlchemy==2.0.44
 SQLAlchemy_Utils==0.41.1
 Werkzeug==2.2.3
 mysqlclient


### PR DESCRIPTION
Fix that starting PyHSS with Python 3.13 fails with the following error by upgrading to the latest SQLAlchemy 2.0.x version:

```
AssertionError: Class <class 'sqlalchemy.sql.elements.SQLCoreOperations'> directly inherits TypingOnly but has additional attributes {'__static_attributes__'}.
```

Related: https://github.com/sqlalchemy/sqlalchemy/issues/11334