### PR TITLE
requirements.txt: set pyosmocom==0.0.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ prometheus_client==0.16.0
 pycryptodome==3.17
 pymongo==4.3.3
 pysctp==0.7.2
-pyosmocom
+pyosmocom==0.0.11
 comp128==1.0.0
 alembic
 pysnmp==4.4.12


### PR DESCRIPTION
Set a specific pyosmocom version to ensure we don't have an earlier version, and to make debugging regressions earlier by having better control over which version is installed.

I have just released version 0.0.11 of pyosmocom and pushed it to [PyPI](https://pypi.org/project/pyosmocom/0.0.11/). With the prior version a GSUP Update Location Request would result in "Error handling GSUP message: 'ton_npi'".