### PR TITLE
GSUP: msg builder with pdp: remove empty qos

### DIFF
--- a/lib/gsup/protocol/gsup_msg.py
+++ b/lib/gsup/protocol/gsup_msg.py
@@ -77,13 +77,9 @@ class GsupMessageBuilder:
             }
         })
 
-        pdp_info.append(
-            {
-                'access_point_name': apn_name
-            }
-        )
-
-        pdp_info.append({'qos': None})
+        pdp_info.append({
+            'access_point_name': apn_name
+        })
 
         return self.with_ie('pdp_info', pdp_info)
 


### PR DESCRIPTION
Remove the empty QoS IE to get closer to what OsmoHLR sends (it doesn't send a QoS IE). Tweak formatting of "access_point_name" while at it to be consistent with the above.