### PR TITLE
Re-enable debian package publishing

### DIFF
--- a/.github/workflows/debian-package.yaml
+++ b/.github/workflows/debian-package.yaml
@@ -33,10 +33,7 @@ jobs:
     permissions:
       contents: write
     needs: build
-    # FIXME: temporarily disabled until this bug in the github API is fixed:
-    # https://github.com/ncipollo/release-action/issues/570#issuecomment-3573222985
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    if: false
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This reverts commit b767882af005f5a93c6f6ee724d02b859b7f3311.

[The underlying issue seems to have been resolved](https://github.com/orgs/community/discussions/180355#discussioncomment-15082072) and I can confirm this on my own repo:

https://github.com/Takuto88/pyhss/releases/tag/v0.0.7-test
https://github.com/Takuto88/pyhss/actions/runs/19706861840/job/56456758781