### PR TITLE
fix(debian): use correct tag scheme

### DIFF
--- a/.github/workflows/debian-package.yaml
+++ b/.github/workflows/debian-package.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "master" ]
     tags:
-      - "v*"
+      - "*"
   pull_request:
     branches: [ "master" ]
 
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: write
     needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I assumed tags start with 'v' while they actually start with a number.