### PR TITLE
apiService: drop a lot of print()

### DIFF
--- a/services/apiService.py
+++ b/services/apiService.py
@@ -342,13 +342,10 @@ class PyHSS_APN_Get(Resource):
         '''Update APN data for specified APN ID'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             apn_data = databaseClient.UpdateObj(APN, json_data, apn_id, False, operation_id)
 
-            print("Updated object")
-            print(apn_data)
             return apn_data, 200
         except Exception as E:
             print(E)
@@ -362,7 +359,6 @@ class PyHSS_APN(Resource):
         '''Create new APN'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             apn_id = databaseClient.CreateObj(APN, json_data, False, operation_id)
@@ -416,14 +412,11 @@ class PyHSS_AUC_Get(Resource):
         '''Update AuC data for specified AuC ID'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             auc_data = databaseClient.UpdateObj(AUC, json_data, auc_id, False, operation_id)
             if not insecureAuc:
                 auc_data = databaseClient.Sanitize_Keys(auc_data)
-            print("Updated object")
-            print(auc_data)
             
             return auc_data, 200
         except Exception as E:
@@ -464,7 +457,6 @@ class PyHSS_AUC(Resource):
         '''Create new AUC'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(AUC, json_data, False, operation_id)
@@ -499,11 +491,8 @@ class PyHSS_AUC_Get_EAP_AKA_Vectors(Resource):
         try:
             #Get data from AuC
             auc_data = databaseClient.Get_AuC(imsi=imsi)
-            print("Got AuC Data OK - Generating Vectors")
             plmn = diameterClient.EncodePLMN(mcc=plmn[0:3], mnc=plmn[3:])
-            print("Encoded PLMN into: " + str(plmn))
             vector_dict = databaseClient.Get_Vectors_AuC(auc_data['auc_id'], action='eap_aka', plmn=plmn)
-            print("Got Vectors: " + str(vector_dict))
             return vector_dict, 200
         except Exception as E:
             print(E)
@@ -516,11 +505,8 @@ class PyHSS_AUC_Get_AKA_Vectors(Resource):
         try:
             #Get data from AuC
             auc_data = databaseClient.Get_AuC(imsi=imsi)
-            print("Got AuC Data OK - Generating " + str(vector_count) + " Vectors")
-            
             plmn = diameterClient.EncodePLMN(mcc=config['hss']['MCC'], mnc=config['hss']['MNC'])
             vector_dict = databaseClient.Get_Vectors_AuC(auc_data['auc_id'], action='aka', plmn=plmn, requested_vectors=int(vector_count))
-            print("Got Vectors: " + str(vector_dict))
             return vector_dict, 200
         except Exception as E:
             print(E)
@@ -556,7 +542,6 @@ class PyHSS_SUBSCRIBER_Get(Resource):
             json_data = request.get_json(force=True)
             if 'msisdn' in json_data:
                 json_data['msisdn'] = json_data['msisdn'].replace('+', '')
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.UpdateObj(SUBSCRIBER, json_data, subscriber_id, False, operation_id)
@@ -600,7 +585,6 @@ class PyHSS_SUBSCRIBER(Resource):
             json_data = request.get_json(force=True)
             if 'msisdn' in json_data:
                 json_data['msisdn'] = json_data['msisdn'].replace('+', '')
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(SUBSCRIBER, json_data, False, operation_id)
@@ -653,7 +637,6 @@ class PyHSS_SUBSCRIBER_ROUTING_Create(Resource):
         '''Create new Subscriber Routing Binding'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(SUBSCRIBER_ROUTING, json_data, False, operation_id)
@@ -694,13 +677,10 @@ class PyHSS_SUBSCRIBER_SUBSCRIBER_ROUTING(Resource):
         '''Update SUBSCRIBER data for specified subscriber_routing_id'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.UpdateObj(SUBSCRIBER_ROUTING, json_data, subscriber_routing_id, False, operation_id)
 
-            print("Updated object")
-            print(data)
             return data, 200
         except Exception as E:
             print(E)
@@ -738,13 +718,10 @@ class PyHSS_IMS_SUBSCRIBER_Get(Resource):
                 json_data['msisdn'] = json_data['msisdn'].replace('+', '')
             if 'msisdn_list' in json_data:
                 json_data['msisdn_list'] = json_data['msisdn_list'].replace('+', '')
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.UpdateObj(IMS_SUBSCRIBER, json_data, ims_subscriber_id, False, operation_id)
 
-            print("Updated object")
-            print(data)
             return data, 200
         except Exception as E:
             print(E)
@@ -762,7 +739,6 @@ class PyHSS_IMS_SUBSCRIBER(Resource):
                 json_data['msisdn'] = json_data['msisdn'].replace('+', '')
             if 'msisdn_list' in json_data:
                 json_data['msisdn_list'] = json_data['msisdn_list'].replace('+', '')
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(IMS_SUBSCRIBER, json_data, False, operation_id)
@@ -778,7 +754,6 @@ class PyHSS_IMS_SUBSCRIBER_MSISDN(Resource):
         '''Get IMS data for MSISDN'''
         try:
             data = databaseClient.Get_IMS_Subscriber(msisdn=msisdn)
-            print("Got back: " + str(data))
             return data, 200
         except Exception as E:
             print("Flask Exception: " + str(E))
@@ -790,7 +765,6 @@ class PyHSS_IMS_SUBSCRIBER_IMSI(Resource):
         '''Get IMS data for imsi'''
         try:
             data = databaseClient.Get_IMS_Subscriber(imsi=imsi)
-            print("Got back: " + str(data))
             return data, 200
         except Exception as E:
             print("Flask Exception: " + str(E))
@@ -817,7 +791,6 @@ class PyHSS_ROAMING_RULE(Resource):
         '''Create new Roaming Rule'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(ROAMING_RULE, json_data, False, operation_id)
@@ -868,13 +841,10 @@ class PyHSS_ROAMING_RULE_Get(Resource):
         '''Update data for specified roaming_rule_id'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.UpdateObj(ROAMING_RULE, json_data, roaming_rule_id, False, operation_id)
 
-            print("Updated object")
-            print(data)
             return data, 200
         except Exception as E:
             print(E)
@@ -888,7 +858,6 @@ class PyHSS_ROAMING_NETWORK(Resource):
         '''Create new Roaming Network'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(ROAMING_NETWORK, json_data, False, operation_id)
@@ -939,13 +908,10 @@ class PyHSS_ROAMING_NETWORK_Get(Resource):
         '''Update data for specified roaming_network_id'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.UpdateObj(ROAMING_NETWORK, json_data, roaming_network_id, False, operation_id)
 
-            print("Updated object")
-            print(data)
             return data, 200
         except Exception as E:
             print(E)
@@ -979,13 +945,10 @@ class PyHSS_TFT_Get(Resource):
         '''Update tft_id data for specified tft_id'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.UpdateObj(TFT, json_data, tft_id, False, operation_id)
 
-            print("Updated object")
-            print(data)
             return data, 200
         except Exception as E:
             print(E)
@@ -999,7 +962,6 @@ class PyHSS_TFT(Resource):
         '''Create new TFT'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(TFT, json_data, False, operation_id)
@@ -1050,13 +1012,10 @@ class PyHSS_Charging_Rule_Get(Resource):
         '''Update charging_rule_id data for specified charging_rule_id'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.UpdateObj(CHARGING_RULE, json_data, charging_rule_id, False, operation_id)
 
-            print("Updated object")
-            print(data)
             return data, 200
         except Exception as E:
             print(E)
@@ -1070,7 +1029,6 @@ class PyHSS_Charging_Rule(Resource):
         '''Create new ChargingRule'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(CHARGING_RULE, json_data, False, operation_id)
@@ -1121,13 +1079,10 @@ class PyHSS_EIR_Get(Resource):
         '''Update eir_id data for specified eir_id'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.UpdateObj(EIR, json_data, eir_id, False, operation_id)
 
-            print("Updated object")
-            print(data)
             return data, 200
         except Exception as E:
             print(E)
@@ -1141,7 +1096,6 @@ class PyHSS_EIR(Resource):
         '''Create new EIR Rule'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(EIR, json_data, False, operation_id)
@@ -1261,13 +1215,10 @@ class PyHSS_Attributes_Get(Resource):
         '''Update data for specified attribute ID'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.UpdateObj(SUBSCRIBER_ATTRIBUTES, json_data, subscriber_attributes_id, False, operation_id)
 
-            print("Updated object")
-            print(data)
             return data, 200
         except Exception as E:
             print(E)
@@ -1281,7 +1232,6 @@ class PyHSS_Attributes(Resource):
         '''Create new Attribute for Subscriber'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             data = databaseClient.CreateObj(SUBSCRIBER_ATTRIBUTES, json_data, False, operation_id)
@@ -1523,7 +1473,6 @@ class PyHSS_OAM_Serving_Subs(Resource):
         '''Get all Subscribers served by HSS'''
         try:
             data = databaseClient.Get_Served_Subscribers()
-            print("Got back served Subs: " + str(data))
             return data, 200
         except Exception as E:
             print(E)
@@ -1535,7 +1484,6 @@ class PyHSS_OAM_Serving_Subs_PCRF(Resource):
         '''Get all Subscribers served by PCRF'''
         try:
             data = databaseClient.Get_Served_PCRF_Subscribers()
-            print("Got back served Subs: " + str(data))
             return data, 200
         except Exception as E:
             print(E)
@@ -1547,7 +1495,6 @@ class PyHSS_OAM_Serving_Subs_IMS(Resource):
         '''Get all Subscribers served by IMS'''
         try:
             data = databaseClient.Get_Served_IMS_Subscribers()
-            print("Got back served Subs: " + str(data))
             return data, 200
         except Exception as E:
             print(E)
@@ -1685,12 +1632,10 @@ class PyHSS_OAM_Get_PCRF_Subscriber_all_APN(Resource):
 
             #Resolve Subscriber ID
             subscriber_data = databaseClient.Get_Subscriber(imsi=str(imsi))
-            print("subscriber_data: " + str(subscriber_data))
             serving_sub_final['subscriber_data'] = databaseClient.Sanitize_Datetime(subscriber_data)
 
             #Split the APN list into a list
             apn_list = subscriber_data['apn_list'].split(',')
-            print("Current APN List: " + str(apn_list))
             #Remove the default APN from the list
             try:
                 apn_list.remove(str(subscriber_data['default_apn']))
@@ -1703,9 +1648,7 @@ class PyHSS_OAM_Get_PCRF_Subscriber_all_APN(Resource):
 
             #Get APN ID from APN
             for list_apn_id in apn_list:
-                print("Getting APN ID " + str(list_apn_id))
                 apn_data = databaseClient.Get_APN(list_apn_id)
-                print(apn_data)
                 try:
                     serving_sub_final['apns'][str(apn_data['apn'])] = {}
                     serving_sub_final['apns'][str(apn_data['apn'])] = databaseClient.Sanitize_Datetime(databaseClient.Get_Serving_APN(subscriber_id=subscriber_data['subscriber_id'], apn_id=list_apn_id))
@@ -1713,7 +1656,6 @@ class PyHSS_OAM_Get_PCRF_Subscriber_all_APN(Resource):
                     serving_sub_final['apns'][str(apn_data['apn'])] = {}
                     print("Failed to get Serving APN for APN ID " + str(list_apn_id))
 
-            print("Got back: " + str(serving_sub_final))
             return serving_sub_final, 200
         except Exception as E:
             print("Flask Exception: " + str(E))
@@ -1731,11 +1673,9 @@ class PyHSS_OAM_Get_PCRF_Subscriber(Resource):
 
             #Resolve Subscriber ID
             subscriber_data = databaseClient.Get_Subscriber(imsi=str(imsi))
-            print("subscriber_data: " + str(subscriber_data))
 
             #Split the APN list into a list
             apn_list = subscriber_data['apn_list'].split(',')
-            print("Current APN List: " + str(apn_list))
             #Remove the default APN from the list
             try:
                 apn_list.remove(str(subscriber_data['default_apn']))
@@ -1747,17 +1687,13 @@ class PyHSS_OAM_Get_PCRF_Subscriber(Resource):
 
             #Get APN ID from APN
             for list_apn_id in apn_list:
-                print("Getting APN ID " + str(list_apn_id) + " to see if it matches APN " + str(apn_id))
                 #Get each APN in List
                 apn_data = databaseClient.Get_APN(list_apn_id)
-                print(apn_data)
                 if str(apn_data['apn_id']).lower() == str(apn_id).lower():
-                    print("Matched named APN with APN ID")
                     apn_id_final = apn_data['apn_id']
 
             data = databaseClient.Get_Serving_APN(subscriber_id=subscriber_data['subscriber_id'], apn_id=apn_id_final)
             data = databaseClient.Sanitize_Datetime(data)
-            print("Got back: " + str(data))
             return data, 200
         except Exception as E:
             print("Flask Exception: " + str(E))
@@ -1789,7 +1725,6 @@ class PyHSS_PCRF(Resource):
         '''Push predefined Charging Rule to Subscriber'''
     
         json_data = request.get_json(force=True)
-        print("JSON Data sent: " + str(json_data))
         #Get IMSI
         subscriber_data = databaseClient.Get_Subscriber(imsi=str(json_data['imsi']))
         print("subscriber_data: " + str(subscriber_data))
@@ -2037,13 +1972,10 @@ class PyHSS_EMERGENCY_SUBSCRIBER_Get(Resource):
         '''Update emergency_subscriber data for specified emergency_subscriber ID'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             apn_data = databaseClient.UpdateObj(EMERGENCY_SUBSCRIBER, json_data, emergency_subscriber_id, False, operation_id)
 
-            print("Updated object")
-            print(apn_data)
             return apn_data, 200
         except Exception as E:
             print(E)
@@ -2057,7 +1989,6 @@ class PyHSS_EMERGENCY_SUBSCRIBER(Resource):
         '''Create new EMERGENCY_SUBSCRIBER'''
         try:
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             args = parser.parse_args()
             operation_id = args.get('operation_id', None)
             emergency_subscriber_id = databaseClient.CreateObj(EMERGENCY_SUBSCRIBER, json_data, False, operation_id)
@@ -2353,7 +2284,6 @@ class PyHSS_Push_CLR(Resource):
         try:
             '''Push CLR (Cancel Location Request) to MME'''
             json_data = request.get_json(force=True)
-            print("JSON Data sent: " + str(json_data))
             if 'DestinationHost' not in json_data:
                 json_data['DestinationHost'] = None
             diameterRequest = diameterClient.sendDiameterRequest(


### PR DESCRIPTION
print() shouldn't used in production code.
Remove most of the simple print() which seemed to be used while developing.
The remaining print() might be converted into LogTool lines. Some of the print() also contained key material or derived key material (vectors).