### PR TITLE
39C3 GSUP fixes

### DIFF
--- a/lib/gsup/controller/isr.py
+++ b/lib/gsup/controller/isr.py
@@ -66,7 +66,7 @@ class ISRController(GsupController):
     async def handle_message(self, peer: IPAPeer, message: GsupMessage):
         transaction = self.__find_transaction_for_imsi(message, peer)
         if transaction.is_finished():
-            raise ValueError(f"ULR Transaction for peer {peer.name} is already finished")
+            raise ValueError(f"ISD Transaction for peer {peer.name} is already finished")
 
         await transaction.continue_invoke(message)
 

--- a/lib/gsup/controller/isr.py
+++ b/lib/gsup/controller/isr.py
@@ -1,6 +1,6 @@
 # PyHSS GSUP Insert Subscriber Data Request Controller
-# Copyright 2025 Lennart Rosam <hello@takuto.de>
-# Copyright 2025 Alexander Couzens <lynxis@fe80.eu>
+# Copyright 2025-2026 Lennart Rosam <hello@takuto.de>
+# Copyright 2025-2026 Alexander Couzens <lynxis@fe80.eu>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 from enum import IntEnum
 from typing import Dict, Callable, Awaitable, Optional

--- a/lib/gsup/controller/ulr.py
+++ b/lib/gsup/controller/ulr.py
@@ -100,7 +100,7 @@ class ULRTransaction(AbstractTransaction):
 
 
 class ULRController(GsupController):
-    def __init__(self, logger: LogTool, database: Database, ulr_transactions: Dict[str, ULRTransaction], all_peers: Dict[str, IPAPeer]):
+    def __init__(self, logger: LogTool, database: Database, ulr_transactions: Dict[tuple[str, str], ULRTransaction], all_peers: Dict[str, IPAPeer]):
         super().__init__(logger, database)
         self.__ulr_transactions = ulr_transactions
         self.__all_ipa_peers = all_peers
@@ -159,7 +159,7 @@ class ULRController(GsupController):
                     raise ULRError(f"RAT {rat_type_to_check.value} not allowed for subscriber {imsi}", GMMCause.NO_SUIT_CELL_IN_LA)
 
             transaction = ULRTransaction(peer, message, self._send_gsup_response, self.__update_subscriber, subscriber_info)
-            self.__ulr_transactions[peer.name] = transaction
+            self.__ulr_transactions[(peer.name, imsi)] = transaction
             await transaction.begin_invoke()
         except ULRError as e:
             await self._logger.logAsync(service='GSUP', level='WARN', message=e.message)

--- a/lib/gsup/controller/ulr.py
+++ b/lib/gsup/controller/ulr.py
@@ -1,6 +1,6 @@
 # PyHSS GSUP Update Location Request Controller
-# Copyright 2025 Lennart Rosam <hello@takuto.de>
-# Copyright 2025 Alexander Couzens <lynxis@fe80.eu>
+# Copyright 2025-2026 Lennart Rosam <hello@takuto.de>
+# Copyright 2025-2026 Alexander Couzens <lynxis@fe80.eu>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import traceback
 from enum import IntEnum

--- a/lib/gsup/request_dispatcher.py
+++ b/lib/gsup/request_dispatcher.py
@@ -1,6 +1,6 @@
 # PyHSS GSUP Request dispatcher
-# Copyright 2025 Lennart Rosam <hello@takuto.de>
-# Copyright 2025 Alexander Couzens <lynxis@fe80.eu>
+# Copyright 2025-2026 Lennart Rosam <hello@takuto.de>
+# Copyright 2025-2026 Alexander Couzens <lynxis@fe80.eu>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 from typing import Dict
 

--- a/lib/gsup/request_dispatcher.py
+++ b/lib/gsup/request_dispatcher.py
@@ -22,8 +22,8 @@ from logtool import LogTool
 
 class GsupRequestDispatcher:
     def __init__(self, logger: LogTool, database: Database, all_peers: Dict[str, IPAPeer]):
-        self.__ulr_transactions: Dict[str, ULRTransaction] = dict()
-        self.__isd_transactions: Dict[str, ISDTransaction] = dict()
+        self.__ulr_transactions: Dict[tuple[str, str], ULRTransaction] = dict()
+        self.__isd_transactions: Dict[tuple[str, str], ISDTransaction] = dict()
         self.logger = logger
         self.database = database
         self.__all_peers = all_peers
@@ -42,13 +42,13 @@ class GsupRequestDispatcher:
 
     async def dispatch(self, peer: IPAPeer, request: GsupMessage):
         # clean up old transactions
-        ulr_to_remove = [peer_name for peer_name, trx in self.__ulr_transactions.items() if trx.is_finished()]
-        for peer_name in ulr_to_remove:
-            del self.__ulr_transactions[peer_name]
+        ulr_to_remove = [(peer_name, imsi) for (peer_name, imsi), trx in self.__ulr_transactions.items() if trx.is_finished()]
+        for peer_name, imsi in ulr_to_remove:
+            del self.__ulr_transactions[(peer_name, imsi)]
 
-        isd_to_remove = [peer_name for peer_name, trx in self.__isd_transactions.items() if trx.is_finished()]
-        for peer_name in isd_to_remove:
-            del self.__isd_transactions[peer_name]
+        isd_to_remove = [(peer_name, imsi) for (peer_name, imsi), trx in self.__isd_transactions.items() if trx.is_finished()]
+        for peer_name, imsi in isd_to_remove:
+            del self.__isd_transactions[(peer_name, imsi)]
 
         if request.msg_type in self.controller_mapping:
             await self.controller_mapping[request.msg_type].handle_message(peer, request)

--- a/services/apiService.py
+++ b/services/apiService.py
@@ -2,7 +2,8 @@
 # Copyright 2022-2025 Nick <nick@nickvsnetworking.com>
 # Copyright 2023-2025 David Kneipp <david@davidkneipp.com>
 # Copyright 2025 sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
-# Copyright 2025 Lennart Rosam <hello@takuto.de>
+# Copyright 2025-2026 Lennart Rosam <hello@takuto.de>
+# Copyright 2025-2026 Alexander Couzens <lynxis@fe80.eu>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import sys
 import json

--- a/services/apiService.py
+++ b/services/apiService.py
@@ -567,27 +567,27 @@ class PyHSS_SUBSCRIBER_Get(Resource):
             data = databaseClient.UpdateObj(SUBSCRIBER, json_data, subscriber_id, False, operation_id)
 
             #If the subscriber is enabled, trigger an ISD in 2G
-            if 'enabled' in json_data and json_data['enabled'] == True:
-                update_event = databaseClient.Get_Gsup_SubscriberInfo(json_data['imsi'])
+            if 'enabled' in data and data['enabled'] == True:
+                update_event = databaseClient.Get_Gsup_SubscriberInfo(data['imsi'])
                 redisMessaging.sendMessage('subscriber_update', update_event.model_dump_json())
 
             #If the "enabled" flag on the subscriber is now disabled, trigger a CLR
-            if 'enabled' in json_data and json_data['enabled'] == False:
+            if 'enabled' in data and data['enabled'] == False:
                 print("Subscriber is now disabled, checking to see if we need to trigger a CLR")
                 #See if we have a serving MME set
                 try:
-                    assert(json_data['serving_mme'])
+                    assert(data['serving_mme'])
                     print("Serving MME set - Sending CLR")
 
                     diameterClient.sendDiameterRequest(
                         requestType='CLR',
-                        hostname=json_data['serving_mme'],
-                        imsi=json_data['imsi'], 
-                        DestinationHost=json_data['serving_mme'], 
-                        DestinationRealm=json_data['serving_mme_realm'], 
+                        hostname=data['serving_mme'],
+                        imsi=data['imsi'],
+                        DestinationHost=data['serving_mme'],
+                        DestinationRealm=data['serving_mme_realm'],
                         CancellationType=1
                     )
-                    print("Sent CLR via Peer " + str(json_data['serving_mme']))
+                    print("Sent CLR via Peer " + str(data['serving_mme']))
                 except:
                     print("No serving MME set - Not sending CLR")
             return data, 200


### PR DESCRIPTION
This branch contains a couple of bugfixes that were authored during 39C3 for the GSUP implementation of the insert subscriber data / update location procedures. They originally stem from @lynxis's branch here but have been cleaned up for upstreaming: https://github.com/lynxis/pyhss/commits/39c3/

The only commit that I am not sure of is [5abb85d](https://github.com/nickvsnetworking/pyhss/pull/301/commits/5abb85dbddeb91b013f6d85af18252ede1db6aad). There was an issue with the ISRs not being triggered correctly. I suspect that this was a first shot at fixing this and the "real" fixes were actually made in [6fcebf1](https://github.com/nickvsnetworking/pyhss/pull/301/commits/6fcebf1e7e2089972607cbb3f2dc8a79182b72e5). Maybe @lynxis  can chime in and explain? 

In any case the change in 5abb85d does not break anything and it did work correctly during the event, therefore I included it.