### PR TITLE
feat: add USSD support for 2G/3G via GSUP

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"  # Debian 10
+          - "3.11"  # Debian 12
           - "3.13"  # Debian 13
           - "3.14"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set the default database backend to SQLite.
 - Change the default bind IP from 0.0.0.0 to 127.0.0.1.
+- Raise minimum Python version from 3.9 to 3.11.
 
 ### Removed
 

--- a/config.yaml
+++ b/config.yaml
@@ -101,6 +101,14 @@ hss:
   gsup:
     bind_ip: "127.0.0.1"
     bind_port: 4222
+    # Simple 2G / 3G USSD support via GSUP.
+    # Define USSD codes and messages here. The %msisdn% and %imsi% variables can be used in messages.
+    ussd:
+      codes:
+        - code: "*#100#"
+          msg: "Your MSISDN is %msisdn%"
+        - code: "*#101#"
+          msg: "Your IMSI is %imsi%"
 
 api:
   bind_ip: "127.0.0.1"

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -101,6 +101,14 @@ hss:
   gsup:
     bind_ip: "${HSS_GSUP_BIND_IP:-0.0.0.0}"
     bind_port: ${HSS_GSUP_BIND_PORT:-4222}
+    # Simple 2G / 3G USSD support via GSUP.
+    # Define USSD codes and messages here. The %msisdn% and %imsi% variables can be used in messages.
+    ussd:
+      codes:
+        - code: "*#100#"
+          msg: "Your MSISDN is: %msisdn%"
+        - code: "*#101#"
+          msg: "Your IMSI is: %imsi%"
 
 api:
   bind_ip: "${API_BIND_IP:-0.0.0.0}"

--- a/lib/gsup/controller/ss.py
+++ b/lib/gsup/controller/ss.py
@@ -1,0 +1,236 @@
+# PyHSS GSUP SS Controller
+# Copyright 2025-2026 Alexander Couzens <lynxis@fe80.eu>
+# Copyright 2026 Lennart Rosam <hello@takuto.de>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import binascii
+import traceback
+from collections import OrderedDict
+from pathlib import Path
+
+import asn1tools
+from gsup.controller.abstract_controller import GsupController
+from gsup.protocol.gsup_msg import GsupMessageBuilder, GsupMessageUtil
+from osmocom.gsup.message import MsgType
+from pyhss_config import config
+from smspdudecoder.codecs import GSM
+
+# GSM MAP local error codes (see GSMMAPLocalErrorcode in ussd.asn1)
+MAP_ERR_UNKNOWN_SUBSCRIBER = 1
+MAP_ERR_FACILITY_NOT_SUPPORTED = 21
+MAP_ERR_SS_NOT_AVAILABLE = 18
+MAP_ERR_SYSTEM_FAILURE = 34
+MAP_ERR_DATA_MISSING = 35
+MAP_ERR_UNEXPECTED_DATA_VALUE = 36
+
+
+class USSDError(RuntimeError):
+    """USSD handling failed.
+
+    Carries the GSM MAP local error code to return to the MS and,
+    when known, the TCAP invoke ID of the failed operation.
+    """
+    def __init__(self, message, error_code=MAP_ERR_SYSTEM_FAILURE, invoke_id=None):
+        super().__init__(message)
+        self.error_code = error_code
+        self.invoke_id = invoke_id
+
+
+class UnknownUSSD(USSDError):
+    """ Unknown USSD message """
+
+
+asn1path = Path(__file__).with_name("ussd.asn1").resolve()
+USSD = asn1tools.compile_files([str(asn1path)])
+
+class SSController(GsupController):
+    def __init__(self, logger, database):
+        super().__init__(logger, database)
+
+        ussd_config = config.get('hss', {}).get('gsup', {}).get('ussd', {})
+        if not ussd_config or not ussd_config.get('codes', []):
+            self.targets = {}
+        else:
+            ussd_targets = ussd_config.get('codes', [])
+            self.targets = {code['code']: code['msg'] for code in ussd_targets}
+
+
+    @staticmethod
+    def end_session_response(message: dict):
+        """Generate a session-end response by reusing fields from the request."""
+        response = GsupMessageBuilder().with_msg_type(MsgType.PROC_SS_RESULT)
+
+        GsupMessageUtil.copy_field_to_builder('imsi', message, response)
+        GsupMessageUtil.copy_field_to_builder('session_id', message, response)
+
+        return response.with_ie('session_state', 'end').build()
+
+    @staticmethod
+    def gsup_from_ussd(message: dict, ussd_encoded: bytes):
+        """ Generate a full GSUP message """
+        response = GsupMessageBuilder().with_msg_type(MsgType.PROC_SS_RESULT)
+
+        GsupMessageUtil.copy_field_to_builder('imsi', message, response)
+        GsupMessageUtil.copy_field_to_builder('session_id', message, response)
+
+        return response.with_ie('session_state', 'end').with_ie('supplementary_service_info', ussd_encoded).build()
+
+    @staticmethod
+    def encode_ussd_arg(answer: str) -> bytes:
+        """
+        Encode USSD-Arg of MAP into bytes
+
+        OrderedDict([('ussd-DataCodingScheme', b'\x0f'),
+             ('ussd-String', b'\xaaQ\x0c\x06\x1b\x01')])
+        """
+        # GSM 03.38: when 7 spare bits remain in the last octet, pad with
+        # a CR septet so the receiver does not decode the padding as '@'.
+        septets = sum(2 if char in GSM.ALPHABET_EXT.values() else 1 for char in answer)
+        if septets % 8 == 7:
+            answer += '\r'
+
+        attr = USSD.modules['USSD']['USSD-Arg']
+        data = OrderedDict()
+        data['ussd-DataCodingScheme'] = b'\x0f'
+        data['ussd-String'] = binascii.a2b_hex(GSM().encode(answer))
+
+        return attr.encode(data)
+    
+    @staticmethod
+    def encode_map_component(invoke_id: int, answer: str):
+        """
+        Encode a MAP returnResultLast component.
+
+        The result should look like this:
+            ('returnResultLast',
+                OrderedDict(
+                  ('invokeID', 1),
+                  ('resultretres',
+                        OrderedDict(('opCode', ('localValue', 59)),
+                                ('returnparameter',
+                                 bytearray(b'0\x1e\x04\x01\x0f\x04\x19\xd9w]\x0eJ'
+                                           b'6\xa7IPz\x0e\x92\xd9d4\x99\xed'
+                                           b'F\xbb\xe1f0\x99\xad\x06'))))))
+        """
+        comp = USSD.modules['USSD']['Component']
+        outer = OrderedDict()
+        outer['invokeID'] = invoke_id
+
+        inner = OrderedDict()
+        inner['opCode'] = ('localValue', 59)
+        inner['returnparameter'] = SSController.encode_ussd_arg(answer)
+        outer['resultretres'] = inner
+
+        answer = comp.encode(('returnResultLast', outer))
+        return answer
+
+    @staticmethod
+    def encode_error_component(invoke_id: int, error_code: int) -> bytes:
+        """Encode a MAP returnError component."""
+        comp = USSD.modules['USSD']['Component']
+        error = OrderedDict()
+        error['invokeID'] = invoke_id
+        error['errorCode'] = ('localValue', error_code)
+        return comp.encode(('returnError', error))
+
+    @staticmethod
+    def _peek_invoke_id(ussd_data):
+        """Best-effort extraction of the invoke ID for error reporting."""
+        if ussd_data is None:
+            return None
+        try:
+            _, data = USSD.decode('Component', ussd_data)
+            return data.get('invokeID') if isinstance(data, dict) else None
+        except Exception:
+            return None
+
+    async def _send_error(self, peer, message, invoke_id, error_code):
+        """End the session; attach a MAP returnError when possible."""
+        if invoke_id is not None:
+            component = self.encode_error_component(invoke_id, error_code)
+            response = self.gsup_from_ussd(message, component)
+        else:
+            response = self.end_session_response(message)
+        await self._send_gsup_response(peer, response)
+
+    async def handle_ussd(self, peer, message, subscriber, ussd_data):
+        op, data = USSD.decode('Component', ussd_data)
+        if op == "invoke":
+            if data['opCode'] != ('localValue', 59):
+                raise UnknownUSSD(f"Invalid opCode in invoke {data}",
+                                  error_code=MAP_ERR_FACILITY_NOT_SUPPORTED,
+                                  invoke_id=data['invokeID'])
+
+            invoke_id = data['invokeID']
+            ussd = USSD.decode('USSD-Arg', data['invokeparameter'])
+            target = GSM().decode(str(binascii.b2a_hex(ussd['ussd-String']), 'utf-8'),
+                                  strip_padding=True)
+            await self._logger.logAsync(service='GSUP', level='INFO', message=f"Received USSD request {target}")
+
+            if target not in self.targets:
+                raise UnknownUSSD(f"Unknown USSD code: {target}",
+                                  error_code=MAP_ERR_SS_NOT_AVAILABLE,
+                                  invoke_id=invoke_id)
+
+            ussd_response = self.targets[target]
+            if "%imsi%" in ussd_response:
+                ussd_response = ussd_response.replace("%imsi%", subscriber['imsi'])
+            if "%msisdn%" in ussd_response:
+                ussd_response = ussd_response.replace("%msisdn%", subscriber['msisdn'])
+
+            component = self.encode_map_component(invoke_id, ussd_response)
+            response = self.gsup_from_ussd(message, component)
+            await self._send_gsup_response(peer, response)
+            return
+        elif op in ("returnResultLast", "returnResultNotLast", "returnError"):
+            # A result or error from the peer concludes the operation;
+            # answering it with a counter-error would be wrong. Fall
+            # through to a quiet end-session response.
+            pass
+        else:
+            invoke_id = data.get('invokeID') if isinstance(data, dict) else None
+            raise UnknownUSSD(f"Invalid class or constructed {op} with {data}",
+                              error_code=MAP_ERR_UNEXPECTED_DATA_VALUE,
+                              invoke_id=invoke_id)
+
+        response = self.end_session_response(message)
+        await self._send_gsup_response(peer, response)
+
+    async def handle_message(self, peer, message):
+        message = message.to_dict()
+        ussd_data = GsupMessageUtil.get_first_ie_by_name('supplementary_service_info', message)
+
+        try:
+            imsi = GsupMessageUtil.get_first_ie_by_name('imsi', message)
+            if imsi is None:
+                raise USSDError("IMSI not found in SS message",
+                                error_code=MAP_ERR_DATA_MISSING)
+
+            # Currently, we only support non-continuous sessions
+            session_state = GsupMessageUtil.get_first_ie_by_name('session_state', message)
+            if session_state is None:
+                raise USSDError("Session state not found in SS message",
+                                error_code=MAP_ERR_DATA_MISSING)
+
+            session_id = GsupMessageUtil.get_first_ie_by_name('session_id', message)
+            if session_id is None:
+                raise USSDError("Session id not found in SS message",
+                                error_code=MAP_ERR_DATA_MISSING)
+
+            subscriber = self._database.Get_Subscriber(imsi=imsi)
+            if subscriber is None:
+                raise USSDError(f"No subscriber found for IMSI={imsi}",
+                                error_code=MAP_ERR_UNKNOWN_SUBSCRIBER)
+
+            await self.handle_ussd(peer, message, subscriber, ussd_data)
+
+        except USSDError as e:
+            await self._logger.logAsync(service='GSUP', level='ERROR',
+                                        message=f"Error while handling USSD from {peer}: {traceback.format_exc()}")
+            invoke_id = e.invoke_id if e.invoke_id is not None else self._peek_invoke_id(ussd_data)
+            await self._send_error(peer, message, invoke_id, e.error_code)
+        except Exception:
+            await self._logger.logAsync(service='GSUP', level='ERROR',
+                                        message=f"Error while handling USSD from {peer}: {traceback.format_exc()}")
+            await self._send_error(peer, message, self._peek_invoke_id(ussd_data),
+                                   MAP_ERR_SYSTEM_FAILURE)

--- a/lib/gsup/controller/ussd.asn1
+++ b/lib/gsup/controller/ussd.asn1
@@ -1,0 +1,160 @@
+
+USSD DEFINITIONS ::= BEGIN
+
+MAP-OPERATION   ::= CHOICE {
+                            localValue OperationLocalvalue,
+                            globalValue OBJECT IDENTIFIER }
+
+
+GSMMAPOperationLocalvalue ::= INTEGER{
+    updateLocation (2),
+    cancelLocation (3),
+    provideRoamingNumber (4),
+    noteSubscriberDataModified (5),
+    resumeCallHandling (6),
+    insertSubscriberData (7),
+    deleteSubscriberData (8),
+    sendParameters (9),
+    registerSS (10),
+    eraseSS (11),
+    activateSS (12),
+    deactivateSS (13),
+    interrogateSS (14),
+    notifySS (16),
+    registerPassword (17),
+    getPassword (18),
+    processUnstructuredSS-Data (19),
+    processUnstructuredSS-Request (59)
+}
+
+OperationLocalvalue ::= GSMMAPOperationLocalvalue
+
+
+MAP-ERROR	::=	CHOICE {
+			localValue LocalErrorcode,
+			globalValue OBJECT IDENTIFIER }
+
+GSMMAPLocalErrorcode ::= INTEGER{
+	unknownSubscriber (1),
+	unknownBaseStation (2),
+	unknownMSC (3),
+	secureTransportError (4),
+	unidentifiedSubscriber (5),
+	absentSubscriberSM (6),
+	unknownEquipment (7),
+	roamingNotAllowed (8),
+	illegalSubscriber (9),
+	bearerServiceNotProvisioned (10),
+	teleserviceNotProvisioned (11),
+	illegalEquipment (12),
+	callBarred (13),
+	forwardingViolation (14),
+	cug-Reject (15),
+	illegalSS-Operation (16),
+	ss-ErrorStatus (17),
+	ss-NotAvailable (18),
+	ss-SubscriptionViolation (19),
+	ss-Incompatibility (20),
+	facilityNotSupported (21),
+	ongoingGroupCall (22),
+	invalidTargetBaseStation (23),
+	noRadioResourceAvailable (24),
+	noHandoverNumberAvailable (25),
+	subsequentHandoverFailure (26),
+	absentSubscriber (27),
+	incompatibleTerminal (28),
+	shortTermDenial (29),
+	longTermDenial (30),
+	subscriberBusyForMT-SMS (31),
+	sm-DeliveryFailure (32),
+	messageWaitingListFull (33),
+	systemFailure (34),
+	dataMissing (35),
+	unexpectedDataValue (36),
+	pw-RegistrationFailure (37),
+	negativePW-Check (38),
+	noRoamingNumberAvailable (39),
+	tracingBufferFull (40),
+	targetCellOutsideGroupCallArea (42),
+	numberOfPW-AttemptsViolation (43),
+	numberChanged (44),
+	busySubscriber (45),
+	noSubscriberReply (46),
+	forwardingFailed (47),
+	or-NotAllowed (48),
+	ati-NotAllowed (49),
+	noGroupCallNumberAvailable (50),
+	resourceLimitation (51),
+	unauthorizedRequestingNetwork (52),
+	unauthorizedLCSClient (53),
+	positionMethodFailure (54),
+	unknownOrUnreachableLCSClient (58),
+	mm-EventNotSupported (59),
+	atsi-NotAllowed (60),
+	atm-NotAllowed (61),
+	informationNotAvailable (62),
+	unknownAlphabet (71),
+	ussd-Busy (72)
+}
+
+LocalErrorcode ::= GSMMAPLocalErrorcode
+
+Component ::=   CHOICE {
+			invoke              [1] IMPLICIT Invoke,
+			returnResultLast    [2] IMPLICIT ReturnResult,
+			returnError         [3] IMPLICIT ReturnError,
+			-- TCAP adds returnResultNotLast to allow for the segmentation of a result.
+			returnResultNotLast [7] IMPLICIT ReturnResult
+}
+
+Invoke ::=      SEQUENCE {
+                invokeID            InvokeIdType,
+                linkedID            [0] InvokeIdType OPTIONAL,
+                opCode              MAP-OPERATION,
+                invokeparameter     InvokeParameter OPTIONAL
+}
+InvokeParameter ::= ANY
+
+ReturnResult ::=    SEQUENCE {
+                invokeID                InvokeIdType,
+                resultretres            SEQUENCE {
+                opCode                  MAP-OPERATION,
+                returnparameter         ReturnResultParameter OPTIONAL
+                } OPTIONAL
+            }
+ReturnResultParameter ::= ANY
+
+
+ReturnError ::= SEQUENCE {
+                invokeID                InvokeIdType,
+                errorCode               MAP-ERROR,
+                parameter               ReturnErrorParameter  OPTIONAL }
+
+ReturnErrorParameter ::= ANY
+
+
+InvokeIdType ::=    INTEGER (-128..127)
+
+USSD-Arg ::= SEQUENCE {
+    ussd-DataCodingScheme USSD-DataCodingScheme,
+    ussd-String USSD-String,
+    ... ,
+    alertingPattern AlertingPattern OPTIONAL,
+    msisdn [0] ISDN-AddressString OPTIONAL }
+
+USSD-Res ::= SEQUENCE {
+    ussd-DataCodingScheme USSD-DataCodingScheme,
+    ussd-String USSD-String,
+    ...}
+USSD-DataCodingScheme ::= OCTET STRING (SIZE (1))
+
+USSD-String ::= OCTET STRING (SIZE (1..maxUSSD-StringLength))
+
+maxUSSD-StringLength INTEGER ::= 160
+AlertingPattern ::= OCTET STRING (SIZE (1) )
+ISDN-AddressString ::=
+    AddressString (SIZE (1..maxISDN-AddressLength))
+maxISDN-AddressLength INTEGER ::= 9
+AddressString ::= OCTET STRING (SIZE (1..maxAddressLength))
+maxAddressLength INTEGER ::= 20
+END

--- a/lib/gsup/protocol/gsup_msg.py
+++ b/lib/gsup/protocol/gsup_msg.py
@@ -1,6 +1,6 @@
 # PyHSS GSUP Message Builder - A factory class to create new GSUP Messages
-# Copyright 2025 Lennart Rosam <hello@takuto.de>
-# Copyright 2025 Alexander Couzens <lynxis@fe80.eu>
+# Copyright 2025-2026 Lennart Rosam <hello@takuto.de>
+# Copyright 2025-2026 Alexander Couzens <lynxis@fe80.eu>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 from enum import Enum
 from osmocom.gsup.message import MsgType, GsupMessage
@@ -65,7 +65,7 @@ class GsupMessageBuilder:
         return self.with_ie('pdp_info', pdp_info, False)
 
     def build(self) -> GsupMessage:
-        if 'msg_type' == "":
+        if self.gsup_dict['msg_type'] == "":
             raise ValueError("msg_type is required")
         return GsupMessage.from_dict(self.gsup_dict)
 
@@ -89,6 +89,13 @@ class GsupMessageUtil:
             if ie_name in ie:
                 ies.append(ie)
         return ies
+
+    @staticmethod
+    def copy_field_to_builder(ie_name: str, message: dict, builder: GsupMessageBuilder):
+        """Copy a single IE from a message dict to a GsupMessageBuilder if present."""
+        field = GsupMessageUtil.get_first_ie_by_name(ie_name, message)
+        if field:
+            builder.with_ie(ie_name, field)
 
 
 # 3GPP TS 24.008 Chapter 10.5.5.14 / Table 10.5.147

--- a/lib/gsup/request_dispatcher.py
+++ b/lib/gsup/request_dispatcher.py
@@ -13,6 +13,7 @@ from gsup.controller.air import AIRController
 from gsup.controller.isr import ISRController, ISDTransaction
 from gsup.controller.noop import NoopController
 from gsup.controller.pur import PURController
+from gsup.controller.ss import SSController
 from gsup.controller.ulr import ULRTransaction, ULRController
 from gsup.protocol.gsup_msg import GsupMessageBuilder, GsupMessageUtil
 from gsup.protocol.ipa_peer import IPAPeer
@@ -37,6 +38,11 @@ class GsupRequestDispatcher:
                 MsgType.LOCATION_CANCEL_ERROR: NoopController(logger, database),
                 MsgType.AUTH_FAIL_REPORT: NoopController(logger, database),
                 MsgType.PURGE_MS_REQUEST: PURController(logger, database),
+
+                # USSD
+                MsgType.PROC_SS_REQUEST: SSController(logger, database),
+                MsgType.PROC_SS_ERROR: SSController(logger, database),
+                MsgType.PROC_SS_RESULT: SSController(logger, database),
         }
 
 
@@ -70,7 +76,6 @@ class GsupRequestDispatcher:
             MsgType.LOCATION_CANCEL_REQUEST: MsgType.LOCATION_CANCEL_ERROR,
             MsgType.MO_FORWARD_SM_REQUEST: MsgType.MO_FORWARD_SM_ERROR,
             MsgType.MT_FORWARD_SM_REQUEST: MsgType.MT_FORWARD_SM_ERROR,
-            MsgType.PROC_SS_REQUEST: MsgType.PROC_SS_ERROR,
             MsgType.READY_FOR_SM_REQUEST: MsgType.READY_FOR_SM_ERROR,
         }
 

--- a/lib/rat.py
+++ b/lib/rat.py
@@ -1,11 +1,7 @@
 # PyHSS RAT Technology restriction handling
 # Copyright 2025 Lennart Rosam <hello@takuto.de>
 # SPDX-License-Identifier: AGPL-3.0-or-later
-try:
-    from enum import StrEnum
-except ImportError:
-    # For Python versions < 3.11, use the strenum package
-    from strenum import StrEnum
+from enum import StrEnum
 
 from typing import Optional, Dict, List
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ packages = [
 [tool.setuptools.package-dir]
 pyhss = ""
 
+[tool.setuptools.package-data]
+"*" = ["*.asn1"]
+
 [tool.pytest.ini_options]
 addopts = "--tb=native"
 log_level = "DEBUG"
@@ -49,10 +52,13 @@ markers = [
 line-length = 120
 include = [
 	"lib/databaseSchema.py",
+	"lib/gsup/controller/ss.py",
+	"lib/gsup/protocol/gsup_msg.py",
 	"lib/pyhss_config.py",
 	"tests/test_database_upgrade_mariadb.py",
 	"tests/test_database_upgrade_postgresql.py",
 	"tests/test_database_upgrade_sqlite.py",
+	"tests/test_gsup_ussd.py",
 	"tests/test_license_headers.py",
 	"tests/test_milenage.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pyhss"
 version = "1.0.2"
+requires-python = ">=3.11"
 
 [project.scripts]
 pyhss_api = "pyhss.services.apiService:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ pydantic_core==2.41.5
 tzlocal==4.3
 influxdb==5.3.1
 xmltodict==0.14.2
-StrEnum==0.4.15; python_version < '3.11'
 
 asn1tools==0.167.0
 smspdudecoder==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,6 @@ tzlocal==4.3
 influxdb==5.3.1
 xmltodict==0.14.2
 StrEnum==0.4.15; python_version < '3.11'
+
+asn1tools==0.167.0
+smspdudecoder==2.2.0

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -38,6 +38,12 @@ hss:
   gsup:
     bind_ip: "127.0.0.1"
     bind_port: 4222
+    ussd:
+      codes:
+        - code: "*#100#"
+          msg: "Your MSISDN is: %msisdn%"
+        - code: "*#101#"
+          msg: "Your IMSI is: %imsi%"
 
 api:
   page_size: 200

--- a/tests/test_gsup_ussd.py
+++ b/tests/test_gsup_ussd.py
@@ -1,0 +1,547 @@
+# PyHSS GSUP USSD Controller tests
+# Copyright 2026 Lennart Rosam <hello@takuto.de>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+import asyncio
+import binascii
+from collections import OrderedDict
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from osmocom.gsup.message import GsupMessage, MsgType
+from smspdudecoder.codecs import GSM
+
+from gsup.controller.ss import USSD, SSController, UnknownUSSD
+from gsup.protocol.gsup_msg import GsupMessageBuilder, GsupMessageUtil
+
+DEFAULT_TARGETS = {"*#100#": "Your MSISDN is: %msisdn%",
+                   "*#101#": "Your IMSI is: %imsi%"}
+DEFAULT_TARGETS_SINGLE = {"*#100#": "Your MSISDN is: %msisdn%"}
+DEFAULT_SUBSCRIBER = {"imsi": "262423403000001", "msisdn": "12345"}
+
+
+def _build_controller(targets, subscriber_data=None):
+    """Create an SSController with response capture for testing."""
+    logger = MagicMock()
+    logger.logAsync = AsyncMock()
+    database = MagicMock()
+    if subscriber_data is not None:
+        database.Get_Subscriber.return_value = subscriber_data
+    controller = SSController(logger=logger, database=database)
+    controller.targets = targets
+    controller._sent_responses = []
+    original_send = controller._send_gsup_response
+    async def capture_send(peer, response):
+        controller._sent_responses.append(response)
+        await original_send(peer, response)
+    controller._send_gsup_response = capture_send
+    return controller
+
+
+def _make_peer():
+    peer = MagicMock()
+    peer.writer = AsyncMock()
+    peer.writer.write = MagicMock()
+    peer.writer.drain = AsyncMock()
+    return peer
+
+
+def _get_ie(response, name):
+    """Extract an IE dict from a GsupMessage by name."""
+    return next((ie for ie in response.to_dict()["ies"] if name in ie), None)
+
+
+def _make_message_dict(imsi="262423403000001", session_state="start", session_id=1,
+                       supplementary_service_info=None):
+    """Build a minimal GsupMessage dict for testing."""
+    ies = []
+    if imsi is not None:
+        ies.append({"imsi": imsi})
+    if session_state is not None:
+        ies.append({"session_state": session_state})
+    if session_id is not None:
+        ies.append({"session_id": session_id})
+    if supplementary_service_info is not None:
+        ies.append({"supplementary_service_info": supplementary_service_info})
+    return {"msg_type": "PROC_SS_REQUEST", "ies": ies}
+
+
+def _encode_ussd_invoke(invoke_id, ussd_code):
+    """Encode a USSD invoke Component using the same USSD schema as SSController."""
+    comp = USSD.modules["USSD"]["Component"]
+    ussd_arg = USSD.modules["USSD"]["USSD-Arg"]
+    ussd_data = OrderedDict()
+    ussd_data["ussd-DataCodingScheme"] = b"\x0f"
+    ussd_data["ussd-String"] = binascii.a2b_hex(GSM().encode(ussd_code))
+    invokeparameter = ussd_arg.encode(ussd_data)
+    invoke_data = OrderedDict()
+    invoke_data["invokeID"] = invoke_id
+    invoke_data["opCode"] = ("localValue", 59)
+    invoke_data["invokeparameter"] = invokeparameter
+    return comp.encode(("invoke", invoke_data))
+
+
+def _decode_ussd_response(ussd_encoded):
+    """Decode the USSD-Response from a GSUP supplementary_service_info IE."""
+    _, data = USSD.decode("Component", ussd_encoded)
+    ussd_arg = USSD.decode("USSD-Arg", data["resultretres"]["returnparameter"])
+    return GSM().decode(str(binascii.b2a_hex(ussd_arg["ussd-String"]), "utf-8"), strip_padding=True)
+
+
+class TestUSSDControllerInit(TestCase):
+    """Test SSController initialization with different configs."""
+
+    @patch("gsup.controller.ss.config")
+    def test_no_ussd_config(self, mock_config):
+        mock_config.get.return_value = {}
+        controller = SSController(logger=None, database=None)
+        self.assertEqual(controller.targets, {})
+
+    @patch("gsup.controller.ss.config")
+    def test_empty_codes(self, mock_config):
+        mock_config.get.return_value = {"gsup": {"ussd": {"codes": []}}}
+        controller = SSController(logger=None, database=None)
+        self.assertEqual(controller.targets, {})
+
+    @patch("gsup.controller.ss.config")
+    def test_with_ussd_config(self, mock_config):
+        ussd_config = {
+            "codes": [
+                {"code": "*#100#", "msg": "MSISDN: %msisdn%"},
+                {"code": "*#101#", "msg": "IMSI: %imsi%"},
+            ],
+        }
+        mock_config.get.return_value = {"gsup": {"ussd": ussd_config}}
+        controller = SSController(logger=None, database=None)
+        expected_targets = {"*#100#": "MSISDN: %msisdn%",
+                            "*#101#": "IMSI: %imsi%"}
+        self.assertEqual(controller.targets, expected_targets)
+
+
+class TestHandleMessage(TestCase):
+    """Test handle_message entry point."""
+
+    def _build(self):
+        return _build_controller(
+            DEFAULT_TARGETS, DEFAULT_SUBSCRIBER)
+
+    def test_handle_message_missing_imsi(self):
+        controller = self._build()
+        peer = _make_peer()
+        message = GsupMessage.from_dict(_make_message_dict(imsi=None))
+        asyncio.run(controller.handle_message(peer, message))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        self.assertIsNotNone(_get_ie(response, "session_state"))
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        self.assertIsNone(_get_ie(response, "supplementary_service_info"))
+
+    def test_handle_message_missing_session_state(self):
+        controller = self._build()
+        peer = _make_peer()
+        message = GsupMessage.from_dict(_make_message_dict(session_state=None))
+        asyncio.run(controller.handle_message(peer, message))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        self.assertIsNotNone(_get_ie(response, "session_state"))
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        self.assertIsNone(_get_ie(response, "supplementary_service_info"))
+
+    def test_handle_message_missing_session_id(self):
+        controller = self._build()
+        peer = _make_peer()
+        message = GsupMessage.from_dict(_make_message_dict(session_id=None))
+        asyncio.run(controller.handle_message(peer, message))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        self.assertIsNotNone(_get_ie(response, "session_state"))
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        self.assertIsNone(_get_ie(response, "supplementary_service_info"))
+
+    def test_handle_message_missing_session_id_with_component(self):
+        """A missing session_id IE must answer with dataMissing (35);
+        the invoke ID is recovered from the component."""
+        controller = self._build()
+        peer = _make_peer()
+        ussd_data = _encode_ussd_invoke(4, "*#100#")
+        message = GsupMessage.from_dict(
+            _make_message_dict(session_id=None, supplementary_service_info=ussd_data))
+        asyncio.run(controller.handle_message(peer, message))
+
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        op, data = USSD.decode("Component", ss_info_ie["supplementary_service_info"])
+        self.assertEqual(op, "returnError")
+        self.assertEqual(data["invokeID"], 4)
+        self.assertEqual(data["errorCode"], ("localValue", 35))
+
+    def test_handle_message_subscriber_not_found(self):
+        controller = self._build()
+        peer = _make_peer()
+        controller._database.Get_Subscriber.return_value = None
+        ussd_data = _encode_ussd_invoke(1, "*#100#")
+        message = GsupMessage.from_dict(_make_message_dict(supplementary_service_info=ussd_data))
+        asyncio.run(controller.handle_message(peer, message))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        self.assertIsNotNone(_get_ie(response, "session_state"))
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        op, data = USSD.decode("Component", ss_info_ie["supplementary_service_info"])
+        self.assertEqual(op, "returnError")
+        self.assertEqual(data["invokeID"], 1)
+        self.assertEqual(data["errorCode"], ("localValue", 1))
+        controller._database.Get_Subscriber.assert_called_with(imsi="262423403000001")
+
+    def test_handle_message_known_code_msisdn(self):
+        controller = self._build()
+        peer = _make_peer()
+        ussd_data = _encode_ussd_invoke(1, "*#100#")
+        message = GsupMessage.from_dict(_make_message_dict(supplementary_service_info=ussd_data))
+        asyncio.run(controller.handle_message(peer, message))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        # Verify MSISDN was substituted in the USSD response
+        decoded_response = _decode_ussd_response(ss_info_ie["supplementary_service_info"])
+        self.assertEqual(decoded_response, "Your MSISDN is: 12345")
+
+    def test_handle_message_known_code_imsi(self):
+        controller = self._build()
+        peer = _make_peer()
+        ussd_data = _encode_ussd_invoke(1, "*#101#")
+        message = GsupMessage.from_dict(_make_message_dict(supplementary_service_info=ussd_data))
+        asyncio.run(controller.handle_message(peer, message))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        # Verify IMSI was substituted in the USSD response
+        decoded_response = _decode_ussd_response(ss_info_ie["supplementary_service_info"])
+        self.assertEqual(decoded_response, "Your IMSI is: 262423403000001")
+
+    def test_handle_message_unknown_code(self):
+        """An unknown USSD code must end the session with a MAP
+        returnError carrying ss-NotAvailable (18)."""
+        controller = self._build()
+        peer = _make_peer()
+        ussd_data = _encode_ussd_invoke(1, "*#999#")
+        message = GsupMessage.from_dict(_make_message_dict(supplementary_service_info=ussd_data))
+        asyncio.run(controller.handle_message(peer, message))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        op, data = USSD.decode("Component", ss_info_ie["supplementary_service_info"])
+        self.assertEqual(op, "returnError")
+        self.assertEqual(data["invokeID"], 1)
+        self.assertEqual(data["errorCode"], ("localValue", 18))
+
+    def test_handle_message_invalid_opcode_sends_return_error(self):
+        """An unsupported opCode must end the session with a MAP
+        returnError carrying facilityNotSupported (21)."""
+        controller = self._build()
+        peer = _make_peer()
+        # Build an invoke with opCode 19 (processUnstructuredSS-Data)
+        comp = USSD.modules["USSD"]["Component"]
+        ussd_arg = USSD.modules["USSD"]["USSD-Arg"]
+        arg = OrderedDict()
+        arg["ussd-DataCodingScheme"] = b"\x0f"
+        arg["ussd-String"] = binascii.a2b_hex(GSM().encode("*#100#"))
+        invoke = OrderedDict()
+        invoke["invokeID"] = 5
+        invoke["opCode"] = ("localValue", 19)
+        invoke["invokeparameter"] = ussd_arg.encode(arg)
+        ussd_data = comp.encode(("invoke", invoke))
+
+        message = GsupMessage.from_dict(_make_message_dict(supplementary_service_info=ussd_data))
+        asyncio.run(controller.handle_message(peer, message))
+
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        op, data = USSD.decode("Component", ss_info_ie["supplementary_service_info"])
+        self.assertEqual(op, "returnError")
+        self.assertEqual(data["invokeID"], 5)
+        self.assertEqual(data["errorCode"], ("localValue", 21))
+
+    def test_handle_message_db_error_sends_system_failure(self):
+        """A generic exception must end the session with a MAP
+        returnError carrying systemFailure (34)."""
+        controller = self._build()
+        peer = _make_peer()
+        controller._database.Get_Subscriber.side_effect = RuntimeError("db down")
+        ussd_data = _encode_ussd_invoke(7, "*#100#")
+        message = GsupMessage.from_dict(_make_message_dict(supplementary_service_info=ussd_data))
+        asyncio.run(controller.handle_message(peer, message))
+
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        op, data = USSD.decode("Component", ss_info_ie["supplementary_service_info"])
+        self.assertEqual(op, "returnError")
+        self.assertEqual(data["invokeID"], 7)
+        self.assertEqual(data["errorCode"], ("localValue", 34))
+
+    def test_handle_message_unrecoverable_invoke_id_sends_bare_response(self):
+        """When the invoke ID cannot be recovered from garbage data,
+        the response must still end the session (bare end-session)."""
+        controller = self._build()
+        peer = _make_peer()
+        controller._database.Get_Subscriber.side_effect = RuntimeError("db down")
+        message = GsupMessage.from_dict(_make_message_dict(supplementary_service_info=b"garbage"))
+        asyncio.run(controller.handle_message(peer, message))
+
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        self.assertIsNone(_get_ie(response, "supplementary_service_info"))
+
+    def test_handle_message_incoming_return_error_ends_session_quietly(self):
+        """A returnError from the MS concludes the operation; it must not
+        be answered with a counter-error (TCAP semantics)."""
+        controller = self._build()
+        peer = _make_peer()
+        comp = USSD.modules["USSD"]["Component"]
+        error = OrderedDict()
+        error["invokeID"] = 3
+        error["errorCode"] = ("localValue", 34)
+        ussd_data = comp.encode(("returnError", error))
+
+        message = GsupMessage.from_dict(_make_message_dict(supplementary_service_info=ussd_data))
+        asyncio.run(controller.handle_message(peer, message))
+
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        self.assertIsNone(_get_ie(response, "supplementary_service_info"))
+
+    def test_handle_message_return_result_not_last_ends_session_quietly(self):
+        """A returnResultNotLast must also end the session without a
+        counter-error."""
+        controller = self._build()
+        peer = _make_peer()
+        comp = USSD.modules["USSD"]["Component"]
+        result = OrderedDict()
+        result["invokeID"] = 9
+        ussd_data = comp.encode(("returnResultNotLast", result))
+
+        message = GsupMessage.from_dict(_make_message_dict(supplementary_service_info=ussd_data))
+        asyncio.run(controller.handle_message(peer, message))
+
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        self.assertIsNone(_get_ie(response, "supplementary_service_info"))
+
+
+class TestHandleUSSD(TestCase):
+    """Test handle_ussd internal logic."""
+
+    def test_handle_ussd_valid_invoke(self):
+        controller = _build_controller(
+            DEFAULT_TARGETS_SINGLE)
+        peer = _make_peer()
+        subscriber = {"imsi": "262423403000001", "msisdn": "12345"}
+        message = _make_message_dict()
+        ussd_data = _encode_ussd_invoke(42, "*#100#")
+        asyncio.run(controller.handle_ussd(peer, message, subscriber, ussd_data))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        decoded_response = _decode_ussd_response(ss_info_ie["supplementary_service_info"])
+        self.assertEqual(decoded_response, "Your MSISDN is: 12345")
+
+    def test_handle_ussd_invalid_op_code(self):
+        controller = _build_controller(
+            DEFAULT_TARGETS_SINGLE)
+        peer = _make_peer()
+        subscriber = {"imsi": "262423403000001", "msisdn": "12345"}
+        message = _make_message_dict()
+        # Encode a valid invoke with a different opCode (not 59)
+        comp = USSD.modules["USSD"]["Component"]
+        ussd_arg = USSD.modules["USSD"]["USSD-Arg"]
+        ussd_data_field = OrderedDict()
+        ussd_data_field["ussd-DataCodingScheme"] = b"\x0f"
+        ussd_data_field["ussd-String"] = binascii.a2b_hex(GSM().encode("*#999#"))
+        invokeparameter = ussd_arg.encode(ussd_data_field)
+        invoke_data = OrderedDict()
+        invoke_data["invokeID"] = 1
+        invoke_data["opCode"] = ("localValue", 19)  # processUnstructuredSS-Data, not 59
+        invoke_data["invokeparameter"] = invokeparameter
+        ussd_data = comp.encode(("invoke", invoke_data))
+        with self.assertRaises(UnknownUSSD):
+            asyncio.run(controller.handle_ussd(peer, message, subscriber, ussd_data))
+
+    def test_handle_ussd_return_result_last(self):
+        controller = _build_controller(
+            DEFAULT_TARGETS_SINGLE)
+        peer = _make_peer()
+        subscriber = {"imsi": "262423403000001", "msisdn": "12345"}
+        message = _make_message_dict()
+        # Encode a returnResultLast Component using the same method as encode_map_component
+        component = SSController.encode_map_component(1, "test")
+        ussd_data = component
+        asyncio.run(controller.handle_ussd(peer, message, subscriber, ussd_data))
+        # Should send end_session_response response (pass-through case)
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        self.assertIsNotNone(_get_ie(response, "session_state"))
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+
+    def test_handle_ussd_seven_char_code_with_cr_padding(self):
+        """A 7-septet USSD code is CR-padded by the phone (GSM 03.38);
+        the padding must be stripped before the code lookup."""
+        controller = _build_controller({"*#1234#": "It works"})
+        peer = _make_peer()
+        subscriber = {"imsi": "262423403000001", "msisdn": "12345"}
+        message = _make_message_dict()
+        # Simulate the phone: 7 septets + CR padding septet
+        ussd_data = _encode_ussd_invoke(1, "*#1234#\r")
+        asyncio.run(controller.handle_ussd(peer, message, subscriber, ussd_data))
+        self.assertEqual(len(controller._sent_responses), 1)
+        ss_info_ie = _get_ie(controller._sent_responses[0], "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        decoded_response = _decode_ussd_response(ss_info_ie["supplementary_service_info"])
+        self.assertEqual(decoded_response, "It works")
+
+
+class TestStaticMethods(TestCase):
+    """Test static utility methods."""
+
+    def test_end_session_response(self):
+        message = _make_message_dict()
+        response = SSController.end_session_response(message)
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        self.assertIsNotNone(_get_ie(response, "imsi"))
+        self.assertEqual(_get_ie(response, "imsi")["imsi"], "262423403000001")
+        self.assertIsNotNone(_get_ie(response, "session_id"))
+        self.assertIsNotNone(_get_ie(response, "session_state"))
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+
+    def test_end_session_response_missing_imsi(self):
+        message = _make_message_dict(imsi=None)
+        response = SSController.end_session_response(message)
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        self.assertIsNone(_get_ie(response, "imsi"))
+
+    def test_gsup_from_ussd(self):
+        message = _make_message_dict()
+        ussd_encoded = b"\x00\x01\x02"
+        response = SSController.gsup_from_ussd(message, ussd_encoded)
+        self.assertEqual(response.msg_type, MsgType.PROC_SS_RESULT)
+        self.assertEqual(_get_ie(response, "session_state")["session_state"], "end")
+        self.assertEqual(_get_ie(response, "supplementary_service_info")["supplementary_service_info"], ussd_encoded)
+
+    def test_encode_map_component_roundtrip(self):
+        component = SSController.encode_map_component(42, "Your MSISDN is: 12345")
+        op, data = USSD.decode("Component", component)
+        self.assertEqual(op, "returnResultLast")
+        self.assertEqual(data["invokeID"], 42)
+        self.assertEqual(data["resultretres"]["opCode"], ("localValue", 59))
+        # Verify the returnparameter can be decoded as USSD-Arg
+        ussd_arg = USSD.decode("USSD-Arg", data["resultretres"]["returnparameter"])
+        decoded_str = GSM().decode(str(binascii.b2a_hex(ussd_arg["ussd-String"]), "utf-8"))
+        self.assertEqual(decoded_str, "Your MSISDN is: 12345")
+
+    def test_encode_ussd_arg_roundtrip(self):
+        answer = "Your IMSI is: 262423403000001"
+        encoded = SSController.encode_ussd_arg(answer)
+        ussd_arg = USSD.decode("USSD-Arg", encoded)
+        decoded_str = GSM().decode(str(binascii.b2a_hex(ussd_arg["ussd-String"]), "utf-8"))
+        self.assertEqual(decoded_str, answer)
+
+class TestMessageLengths(TestCase):
+    """Test GSM encoding/decoding with different message lengths.
+
+    Regression test for a prior bug where a trailing '@' character caused
+    5-digit numbers to return as 4-digit with truncated text.
+    """
+
+    def test_short_message(self):
+        controller = _build_controller(
+            DEFAULT_TARGETS, "Code not recognized.")
+        peer = _make_peer()
+        ussd_data = _encode_ussd_invoke(1, "*#100#")
+        message = _make_message_dict()
+        subscriber = {"imsi": "262423403000001", "msisdn": "12345"}
+        asyncio.run(controller.handle_ussd(peer, message, subscriber, ussd_data))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        decoded_response = _decode_ussd_response(ss_info_ie["supplementary_service_info"])
+        self.assertEqual(decoded_response, "Your MSISDN is: 12345")
+
+    def test_long_message(self):
+        controller = _build_controller(
+            DEFAULT_TARGETS, "Code not recognized.")
+        peer = _make_peer()
+        ussd_data = _encode_ussd_invoke(1, "*#100#")
+        message = _make_message_dict()
+        subscriber = {"imsi": "262423403000001", "msisdn": "123456789012345"}
+        asyncio.run(controller.handle_ussd(peer, message, subscriber, ussd_data))
+        self.assertEqual(len(controller._sent_responses), 1)
+        response = controller._sent_responses[0]
+        ss_info_ie = _get_ie(response, "supplementary_service_info")
+        self.assertIsNotNone(ss_info_ie)
+        decoded_response = _decode_ussd_response(ss_info_ie["supplementary_service_info"])
+        self.assertEqual(decoded_response, "Your MSISDN is: 123456789012345")
+
+    def test_encode_ussd_arg_various_lengths(self):
+        """Messages whose septet count % 8 == 7 must not decode with a
+        trailing '@' (GSM 03.38 CR padding)."""
+        for length in [1, 6, 7, 8, 15, 16, 23, 31, 32, 160]:
+            msg = "A" * length
+            encoded = SSController.encode_ussd_arg(msg)
+            ussd_arg = USSD.decode("USSD-Arg", encoded)
+            decoded = GSM().decode(str(binascii.b2a_hex(ussd_arg["ussd-String"]), "utf-8"),
+                                   strip_padding=True)
+            self.assertEqual(decoded, msg, f"Round-trip failed for length {length}")
+
+
+class TestGsupMessageUtilCopyField(TestCase):
+    """Test the copy_field_to_builder helper."""
+
+    def test_copy_field_present(self):
+        message = _make_message_dict()
+        builder = GsupMessageBuilder().with_msg_type(MsgType.SEND_AUTH_INFO_RESULT)
+        GsupMessageUtil.copy_field_to_builder("imsi", message, builder)
+        response = builder.build()
+        self.assertIsNotNone(_get_ie(response, "imsi"))
+        self.assertEqual(_get_ie(response, "imsi")["imsi"], "262423403000001")
+
+    def test_copy_field_missing(self):
+        message = _make_message_dict(imsi=None)
+        builder = GsupMessageBuilder().with_msg_type(MsgType.SEND_AUTH_INFO_RESULT)
+        GsupMessageUtil.copy_field_to_builder("imsi", message, builder)
+        response = builder.build()
+        self.assertIsNone(_get_ie(response, "imsi"))
+
+
+class TestGsupMessageBuilder(TestCase):
+    """Test GsupMessageBuilder."""
+
+    def test_build_without_msg_type_raises(self):
+        builder = GsupMessageBuilder()
+        with self.assertRaises(ValueError):
+            builder.build()


### PR DESCRIPTION
- Introduced USSD configuration handling in `config.yaml`.
- Added support for GSUP USSD operation in `request_dispatcher.py`.
- Implemented `SSController` class to process USSD requests.
- Integrated ASN.1 USSD definitions for encoding/decoding.
- Added new dependencies: `asn1tools` and `smspdudecoder`.

The primary author of this is Alexander Couzens. I (Lennart) only contributed the dynamic configuration of the USSD message, which was hard-coded in the original implementation.