### PR TITLE
requirements: update pydantic/pydantic_core

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
 
     - name: Install dependencies (apt)
       run: |
+        sudo apt-get update
         sudo apt-get -q install -y \
           libsctp-dev \
           mariadb-server \

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ SQLAlchemy_Utils==0.41.1
 Werkzeug==2.2.3
 mysqlclient
 prometheus_flask_exporter
-pydantic==2.8.2
-pydantic_core==2.20.1
+pydantic==2.12.5
+pydantic_core==2.41.5
 tzlocal==4.3
 influxdb==5.3.1
 xmltodict==0.14.2


### PR DESCRIPTION
Pick the latest pydantic version and adjust the pydantic-core version (pydantic 2.12.5 depends on pydantic-core==2.41.5). With this change, the pydantic-core binary packages from pip can be used for python 3.14 (python 3.14 builds are not available for the old 2.20.1 version).