### PR TITLE
diameter: fix malformed ULA for subscribers without MSISDN

### DIFF
--- a/lib/diameter.py
+++ b/lib/diameter.py
@@ -261,6 +261,8 @@ class Diameter:
         offset = 0
         output = ''
         matches = ['*', '#', 'a', 'b', 'c']
+        if not all(digit.isdigit() or digit in matches for digit in str(input)):
+            raise ValueError("TBCD_encode input contains non-TBCD characters: " + str(input))
         while offset < len(input):
             if len(input[offset:offset+2]) == 2:
                 self.logTool.log(service='HSS', level='debug', message="processing bits " + str(input[offset:offset+2]) + " at position offset " + str(offset), redisClient=self.redisMessaging)
@@ -2124,10 +2126,13 @@ class Diameter:
         subscription_data += self.generate_vendor_avp(1429, "c0", 10415, APN_Configuration_Profile + APN_Configuration)
 
         try:
-            self.logTool.log(service='HSS', level='debug', message="MSISDN is " + str(subscriber_details['msisdn']) + " - adding in ULA", redisClient=self.redisMessaging)
-            msisdn_avp = self.generate_vendor_avp(701, 'c0', 10415, self.TBCD_encode(str(subscriber_details['msisdn'])))                     #MSISDN
-            self.logTool.log(service='HSS', level='debug', message=msisdn_avp, redisClient=self.redisMessaging)
-            subscription_data += msisdn_avp
+            if subscriber_details.get('msisdn'):
+                self.logTool.log(service='HSS', level='debug', message="MSISDN is " + str(subscriber_details['msisdn']) + " - adding in ULA", redisClient=self.redisMessaging)
+                msisdn_avp = self.generate_vendor_avp(701, 'c0', 10415, self.TBCD_encode(str(subscriber_details['msisdn'])))                     #MSISDN
+                self.logTool.log(service='HSS', level='debug', message=msisdn_avp, redisClient=self.redisMessaging)
+                subscription_data += msisdn_avp
+            else:
+                self.logTool.log(service='HSS', level='debug', message="Subscriber has no MSISDN, not adding MSISDN AVP in ULA", redisClient=self.redisMessaging)
         except Exception as E:
             self.logTool.log(service='HSS', level='error', message="Failed to populate MSISDN in ULA due to error " + str(E), redisClient=self.redisMessaging)
 
@@ -4859,8 +4864,8 @@ class Diameter:
         #* [ Route-Record ]
         avp += self.generate_avp(282, "40", str(binascii.hexlify(b'localdomain'),'ascii'))
         
-        if "msisdn" in kwargs:
-            msisdn = kwargs['msisdn']
+        if kwargs.get("msisdn"):
+            msisdn = str(kwargs['msisdn'])
             msisdn = msisdn.replace('+', '')
             msisdn_avp = self.generate_vendor_avp(701, 'c0', 10415, self.TBCD_encode(str(msisdn)))                                             #MSISDN
             avp += self.generate_vendor_avp(700, "c0", 10415, msisdn_avp)                         #User-Identity
@@ -4933,8 +4938,8 @@ class Diameter:
             avp += self.generate_avp(1, 40, self.string_to_hex(str(kwargs.get('imsi'))))                                             #Username (IMSI)
         
         #MSISDN (Optional)
-        if 'msisdn' in kwargs:
-            avp += self.generate_vendor_avp(701, 'c0', 10415, self.TBCD_encode(str(kwargs.get('msisdn'))))                                             #Username (IMSI)
+        if kwargs.get('msisdn'):
+            avp += self.generate_vendor_avp(701, 'c0', 10415, self.TBCD_encode(str(kwargs.get('msisdn'))))                                             #MSISDN
 
         #GMLC Address
         avp += self.generate_vendor_avp(2405, 'c0', 10415, self.ip_to_hex('127.0.0.1'))                      #GMLC-Address

--- a/tests/test_Diameter.py
+++ b/tests/test_Diameter.py
@@ -61,3 +61,38 @@ class Diameter_Tests(unittest.TestCase):
             "length": 276,
             "packet_version": "01",
         }
+
+    def test_C_TBCD_encode_even_length(self):
+        self.assertEqual(self.__class__.diameter_inst.TBCD_encode("491701234567"), "947110325476")
+
+    def test_C_TBCD_encode_odd_length(self):
+        self.assertEqual(self.__class__.diameter_inst.TBCD_encode("4917012345678"), "947110325476f8")
+
+    def test_C_TBCD_encode_special_chars(self):
+        self.assertEqual(self.__class__.diameter_inst.TBCD_encode("123#"), "21b3")
+
+    def test_C_TBCD_encode_decode_roundtrip(self):
+        msisdn = "262423403000001"
+        encoded = self.__class__.diameter_inst.TBCD_encode(msisdn)
+        self.assertEqual(bytes.fromhex(encoded).hex(), encoded, "TBCD_encode must return valid hex")
+        self.assertEqual(self.__class__.diameter_inst.TBCD_decode(encoded), msisdn)
+
+    def test_C_TBCD_encode_rejects_non_tbcd_input(self):
+        # A subscriber without an MSISDN used to be encoded as str(None) == "None",
+        # embedding the non-hex text "oNen" in the outbound message and crashing
+        # bytes.fromhex() in diameterService.py.
+        for bad_input in (str(None), "12x4", "+491701234567"):
+            with self.assertRaises(ValueError, msg=f"TBCD_encode must reject {bad_input!r}"):
+                self.__class__.diameter_inst.TBCD_encode(bad_input)
+
+    def test_C_SLh_RIR_without_msisdn_is_valid_hex(self):
+        # msisdn=None must be treated as absent, not TBCD-encoded as "None"
+        for kwargs in ({"imsi": "505931111111116", "msisdn": None}, {"imsi": "505931111111116"}):
+            packet = self.__class__.diameter_inst.Request_16777291_8388622(**kwargs)
+            bytes.fromhex(packet)
+
+    def test_C_Sh_UDR_without_msisdn_is_valid_hex(self):
+        # msisdn=None must be treated as absent, not TBCD-encoded as "None"
+        for kwargs in ({"imsi": "505931111111116", "msisdn": None}, {"imsi": "505931111111116"}):
+            packet = self.__class__.diameter_inst.Request_16777217_306(**kwargs)
+            bytes.fromhex(packet)


### PR DESCRIPTION
When a subscriber has no MSISDN set, `Answer_16777251_316()` encoded the value as `TBCD_encode(str(None))`. `TBCD_encode()` swaps digit pairs without validating them, turning `"None"` into the literal text `"oNen"` inside the outbound hex string. Because of this, the diameterService then crashes and closes the connection:

```
[07/20/2026 11:13:40] [INFO] [Diameter] [writeOutboundData] [f9d42e74-52bc-4015-a72d-86fc059b5db1] Connection closed for 192.168.178.147 on port 47461, closing writer.Traceback (most recent call last):
  File "/opt/pyhss/services/diameterService.py", line 314, in writeOutboundData
    diameterOutboundBinary = bytes.fromhex(outboundData.OutboundHex)
```

This commit skips the MSISDN AVP when no MSISDN is set, and makes the `TBCD_encode()` function reject non-TBCD input.

Related issue - #218