### PR TITLE
Fix UnboundLocalError in UAR handler when username decode fails

### DIFF
--- a/lib/diameter.py
+++ b/lib/diameter.py
@@ -2912,6 +2912,7 @@ class Diameter:
             remote_peer = OriginHost
         self.logTool.log(service='HSS', level='debug', message="[diameter.py] [Answer_16777216_300] [UAR] Remote Peer is " + str(remote_peer), redisClient=self.redisMessaging)
 
+        imsi = ""
         try:
             self.logTool.log(service='HSS', level='debug', message="Checking if username present", redisClient=self.redisMessaging)
             username = self.get_avp_data(avps, 1)[0]                                                     


### PR DESCRIPTION
The UAR handler `Answer_16777216_300` reads and decodes the `User-Name` AVP inside a try block and only assigns `imsi` once the decode succeeds. When the request has no `User-Name`, or one that isn't valid hex or UTF-8, the except branch still references `imsi` in the metric label (`str(imsi[0:6])`), so the "unknown user" path double-faults with `UnboundLocalError` and no answer is sent. This initialises `imsi` to an empty string before the try, matching how the other handlers in this file already guard it, so the failure path completes and returns the 5001 result cleanly.

I couldn't add a handler-level test without standing up the redis/database mocks it depends on, but the change mirrors the existing `imsi = ""` guard used elsewhere in `diameter.py`.

Fixes #309
