### PR TITLE
Python 3.14 compat

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ jobs:
         python-version:
           - "3.9"  # Debian 10
           - "3.13"  # Debian 13
+          - "3.14"
 
     steps:
     - uses: actions/checkout@v6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
-Flask==2.2.3
-flask_restx==1.1.0
+Flask==3.1.3
+flask_restx==1.3.2
 Jinja2==3.1.2
 mongo==0.2.0
 prometheus_client==0.16.0
@@ -16,7 +16,6 @@ redis==5.0.0
 Requests==2.31.0
 SQLAlchemy==2.0.44
 SQLAlchemy_Utils==0.41.1
-Werkzeug==2.2.3
 mysqlclient
 prometheus_flask_exporter
 pydantic==2.12.5


### PR DESCRIPTION
Adjust requirements so PyHSS works with Python 3.14 and add it to CI.