### PR TITLE
feat(2g): roaming reject cause for ULR

### DIFF
--- a/lib/gsup/controller/air.py
+++ b/lib/gsup/controller/air.py
@@ -1,6 +1,7 @@
 # PyHSS GSUP Authentication Info Request Controller
 # Copyright 2025 Lennart Rosam <hello@takuto.de>
 # Copyright 2025 Alexander Couzens <lynxis@fe80.eu>
+# Copyright 2026 eta <eta@eta.st>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import traceback
 
@@ -11,9 +12,9 @@ from gsup.controller.abstract_controller import GsupController
 from gsup.protocol.gsup_msg import GsupMessageUtil, GsupMessageBuilder, GMMCause
 from gsup.protocol.ipa_peer import IPAPeer
 from logtool import LogTool
+from pyhss_config import get_unknown_subscriber_2g_reject_cause
 from utils import validate_imsi, InvalidIMSI
 
-from pyhss_config import config
 
 class AIRController(GsupController):
     def __init__(self, logger: LogTool, database: Database):
@@ -27,13 +28,6 @@ class AIRController(GsupController):
         if not ret or ret > max_num:
             return max_num
         return ret
-
-    @staticmethod
-    def _get_unknown_subscriber_reject_cause() -> GMMCause:
-        if config.get('hss', {}).get('roaming', {}).get('inbound', {}).get('reject_unknown_imsis_with', 'IMSI_UNKNOWN') == 'ROAMING_NOT_ALLOWED':
-            return GMMCause.ROAMING_NOTALLOWED
-        else:
-            return GMMCause.IMSI_UNKNOWN
 
     async def handle_message(self, peer: IPAPeer, message: GsupMessage):
         request_dict = message.to_dict()
@@ -87,7 +81,7 @@ class AIRController(GsupController):
                 peer,
                 GsupMessageBuilder().with_msg_type(MsgType.SEND_AUTH_INFO_ERROR)
                 .with_ie('imsi', imsi)
-                .with_ie('cause', self._get_unknown_subscriber_reject_cause().value)
+                .with_ie('cause', get_unknown_subscriber_2g_reject_cause().value)
                 .build(),
             )
         except Exception as e:

--- a/lib/gsup/controller/ulr.py
+++ b/lib/gsup/controller/ulr.py
@@ -1,6 +1,7 @@
 # PyHSS GSUP Update Location Request Controller
 # Copyright 2025-2026 Lennart Rosam <hello@takuto.de>
 # Copyright 2025-2026 Alexander Couzens <lynxis@fe80.eu>
+# Copyright 2026 - eta <eta@eta.st>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import traceback
 from enum import IntEnum
@@ -15,6 +16,7 @@ from gsup.controller.abstract_transaction import AbstractTransaction
 from gsup.protocol.gsup_msg import GsupMessageBuilder, GsupMessageUtil, GMMCause
 from gsup.protocol.ipa_peer import IPAPeer
 from logtool import LogTool
+from pyhss_config import get_unknown_subscriber_2g_reject_cause
 from rat import RAT, SubscriberRATRestriction
 from utils import validate_imsi, InvalidIMSI
 
@@ -152,7 +154,8 @@ class ULRController(GsupController):
                 subscriber_info = self._database.Get_Gsup_SubscriberInfo(imsi)
                 subscriber = self._database.Get_Subscriber(imsi=imsi, get_attributes=True)
             except ValueError as e:
-                raise ULRError(f"Subscriber not found: {imsi}", GMMCause.IMSI_UNKNOWN) from e
+                cause = get_unknown_subscriber_2g_reject_cause()
+                raise ULRError(f"Received ULR for unknown subscriber {imsi}; rejecting with cause {cause.value}", cause) from e
 
             for rat_type_to_check in rat_types_to_check:
                 if not self.__rat_restriction_checker.is_rat_allowed(subscriber['attributes'], rat_type_to_check):

--- a/lib/pyhss_config.py
+++ b/lib/pyhss_config.py
@@ -1,9 +1,13 @@
 # Copyright 2025 sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
+# Copyright 2026 Lennart Rosam <hello@takuto.de>
+# Copyright 2026 eta <eta@eta.st>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import os
 import sys
 import yaml
 from pathlib import Path
+
+from gsup.protocol.gsup_msg import GMMCause
 
 config = None
 
@@ -51,3 +55,10 @@ def validate_config():
 
 load_config()
 validate_config()
+
+
+def get_unknown_subscriber_2g_reject_cause() -> GMMCause:
+    if config.get('hss', {}).get('roaming', {}).get('inbound', {}).get('reject_unknown_imsis_with', 'IMSI_UNKNOWN') == 'ROAMING_NOT_ALLOWED':
+        return GMMCause.ROAMING_NOTALLOWED
+    else:
+        return GMMCause.IMSI_UNKNOWN


### PR DESCRIPTION
During EMF camp, the team needed that to keep phones reliably off their network that used regular sim cards. They somehow got to the ULR step, why and how is not known at this point.