### PR TITLE
Make PyHSS pass with ruff 0.16

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,21 @@
+name: Run linters
+
+on: [push, pull_request]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install ruff
+      run: |
+        pip install "ruff~=0.16.0"
+
+    - name: Run ruff check
+      run: |
+        ruff check
+
+    - name: Run ruff format --check
+      run: |
+        ruff format --check

--- a/lib/databaseSchema.py
+++ b/lib/databaseSchema.py
@@ -1,10 +1,11 @@
 # Copyright 2025 sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
 # SPDX-License-Identifier: AGPL-3.0-or-later
-import sqlalchemy
 import sys
 import time
+
+import sqlalchemy
 from sqlalchemy.engine import Engine
-from sqlalchemy_utils import database_exists, create_database
+from sqlalchemy_utils import create_database, database_exists
 
 
 class DatabaseSchema:

--- a/lib/databaseSchema.py
+++ b/lib/databaseSchema.py
@@ -51,7 +51,7 @@ class DatabaseSchema:
                 result = conn.execute(sqlalchemy.text(sql)).fetchone()
                 if result:
                     ret = result[0]
-        except Exception:
+        except Exception:  # noqa: S110 - ignoring is fine; callers log on failure
             pass
         return ret
 

--- a/lib/gsup/controller/ss.py
+++ b/lib/gsup/controller/ss.py
@@ -30,6 +30,7 @@ class USSDError(RuntimeError):
     Carries the GSM MAP local error code to return to the MS and,
     when known, the TCAP invoke ID of the failed operation.
     """
+
     def __init__(self, message, error_code=MAP_ERR_SYSTEM_FAILURE, invoke_id=None):
         super().__init__(message)
         self.error_code = error_code
@@ -37,43 +38,43 @@ class USSDError(RuntimeError):
 
 
 class UnknownUSSD(USSDError):
-    """ Unknown USSD message """
+    """Unknown USSD message"""
 
 
 asn1path = Path(__file__).with_name("ussd.asn1").resolve()
 USSD = asn1tools.compile_files([str(asn1path)])
 
+
 class SSController(GsupController):
     def __init__(self, logger, database):
         super().__init__(logger, database)
 
-        ussd_config = config.get('hss', {}).get('gsup', {}).get('ussd', {})
-        if not ussd_config or not ussd_config.get('codes', []):
+        ussd_config = config.get("hss", {}).get("gsup", {}).get("ussd", {})
+        if not ussd_config or not ussd_config.get("codes", []):
             self.targets = {}
         else:
-            ussd_targets = ussd_config.get('codes', [])
-            self.targets = {code['code']: code['msg'] for code in ussd_targets}
-
+            ussd_targets = ussd_config.get("codes", [])
+            self.targets = {code["code"]: code["msg"] for code in ussd_targets}
 
     @staticmethod
     def end_session_response(message: dict):
         """Generate a session-end response by reusing fields from the request."""
         response = GsupMessageBuilder().with_msg_type(MsgType.PROC_SS_RESULT)
 
-        GsupMessageUtil.copy_field_to_builder('imsi', message, response)
-        GsupMessageUtil.copy_field_to_builder('session_id', message, response)
+        GsupMessageUtil.copy_field_to_builder("imsi", message, response)
+        GsupMessageUtil.copy_field_to_builder("session_id", message, response)
 
-        return response.with_ie('session_state', 'end').build()
+        return response.with_ie("session_state", "end").build()
 
     @staticmethod
     def gsup_from_ussd(message: dict, ussd_encoded: bytes):
-        """ Generate a full GSUP message """
+        """Generate a full GSUP message"""
         response = GsupMessageBuilder().with_msg_type(MsgType.PROC_SS_RESULT)
 
-        GsupMessageUtil.copy_field_to_builder('imsi', message, response)
-        GsupMessageUtil.copy_field_to_builder('session_id', message, response)
+        GsupMessageUtil.copy_field_to_builder("imsi", message, response)
+        GsupMessageUtil.copy_field_to_builder("session_id", message, response)
 
-        return response.with_ie('session_state', 'end').with_ie('supplementary_service_info', ussd_encoded).build()
+        return response.with_ie("session_state", "end").with_ie("supplementary_service_info", ussd_encoded).build()
 
     @staticmethod
     def encode_ussd_arg(answer: str) -> bytes:
@@ -87,15 +88,15 @@ class SSController(GsupController):
         # a CR septet so the receiver does not decode the padding as '@'.
         septets = sum(2 if char in GSM.ALPHABET_EXT.values() else 1 for char in answer)
         if septets % 8 == 7:
-            answer += '\r'
+            answer += "\r"
 
-        attr = USSD.modules['USSD']['USSD-Arg']
+        attr = USSD.modules["USSD"]["USSD-Arg"]
         data = OrderedDict()
-        data['ussd-DataCodingScheme'] = b'\x0f'
-        data['ussd-String'] = binascii.a2b_hex(GSM().encode(answer))
+        data["ussd-DataCodingScheme"] = b"\x0f"
+        data["ussd-String"] = binascii.a2b_hex(GSM().encode(answer))
 
         return attr.encode(data)
-    
+
     @staticmethod
     def encode_map_component(invoke_id: int, answer: str):
         """
@@ -112,26 +113,26 @@ class SSController(GsupController):
                                            b'6\xa7IPz\x0e\x92\xd9d4\x99\xed'
                                            b'F\xbb\xe1f0\x99\xad\x06'))))))
         """
-        comp = USSD.modules['USSD']['Component']
+        comp = USSD.modules["USSD"]["Component"]
         outer = OrderedDict()
-        outer['invokeID'] = invoke_id
+        outer["invokeID"] = invoke_id
 
         inner = OrderedDict()
-        inner['opCode'] = ('localValue', 59)
-        inner['returnparameter'] = SSController.encode_ussd_arg(answer)
-        outer['resultretres'] = inner
+        inner["opCode"] = ("localValue", 59)
+        inner["returnparameter"] = SSController.encode_ussd_arg(answer)
+        outer["resultretres"] = inner
 
-        answer = comp.encode(('returnResultLast', outer))
+        answer = comp.encode(("returnResultLast", outer))
         return answer
 
     @staticmethod
     def encode_error_component(invoke_id: int, error_code: int) -> bytes:
         """Encode a MAP returnError component."""
-        comp = USSD.modules['USSD']['Component']
+        comp = USSD.modules["USSD"]["Component"]
         error = OrderedDict()
-        error['invokeID'] = invoke_id
-        error['errorCode'] = ('localValue', error_code)
-        return comp.encode(('returnError', error))
+        error["invokeID"] = invoke_id
+        error["errorCode"] = ("localValue", error_code)
+        return comp.encode(("returnError", error))
 
     @staticmethod
     def _peek_invoke_id(ussd_data):
@@ -139,8 +140,8 @@ class SSController(GsupController):
         if ussd_data is None:
             return None
         try:
-            _, data = USSD.decode('Component', ussd_data)
-            return data.get('invokeID') if isinstance(data, dict) else None
+            _, data = USSD.decode("Component", ussd_data)
+            return data.get("invokeID") if isinstance(data, dict) else None
         except Exception:
             return None
 
@@ -154,29 +155,32 @@ class SSController(GsupController):
         await self._send_gsup_response(peer, response)
 
     async def handle_ussd(self, peer, message, subscriber, ussd_data):
-        op, data = USSD.decode('Component', ussd_data)
+        op, data = USSD.decode("Component", ussd_data)
         if op == "invoke":
-            if data['opCode'] != ('localValue', 59):
-                raise UnknownUSSD(f"Invalid opCode in invoke {data}",
-                                  error_code=MAP_ERR_FACILITY_NOT_SUPPORTED,
-                                  invoke_id=data['invokeID'])
+            if data["opCode"] != ("localValue", 59):
+                raise UnknownUSSD(
+                    f"Invalid opCode in invoke {data}",
+                    error_code=MAP_ERR_FACILITY_NOT_SUPPORTED,
+                    invoke_id=data["invokeID"],
+                )
 
-            invoke_id = data['invokeID']
-            ussd = USSD.decode('USSD-Arg', data['invokeparameter'])
-            target = GSM().decode(str(binascii.b2a_hex(ussd['ussd-String']), 'utf-8'),
-                                  strip_padding=True)
-            await self._logger.logAsync(service='GSUP', level='INFO', message=f"Received USSD request {target}")
+            invoke_id = data["invokeID"]
+            ussd = USSD.decode("USSD-Arg", data["invokeparameter"])
+            target = GSM().decode(str(binascii.b2a_hex(ussd["ussd-String"]), "utf-8"), strip_padding=True)
+            await self._logger.logAsync(service="GSUP", level="INFO", message=f"Received USSD request {target}")
 
             if target not in self.targets:
-                raise UnknownUSSD(f"Unknown USSD code: {target}",
-                                  error_code=MAP_ERR_SS_NOT_AVAILABLE,
-                                  invoke_id=invoke_id)
+                raise UnknownUSSD(
+                    f"Unknown USSD code: {target}",
+                    error_code=MAP_ERR_SS_NOT_AVAILABLE,
+                    invoke_id=invoke_id,
+                )
 
             ussd_response = self.targets[target]
             if "%imsi%" in ussd_response:
-                ussd_response = ussd_response.replace("%imsi%", subscriber['imsi'])
+                ussd_response = ussd_response.replace("%imsi%", subscriber["imsi"])
             if "%msisdn%" in ussd_response:
-                ussd_response = ussd_response.replace("%msisdn%", subscriber['msisdn'])
+                ussd_response = ussd_response.replace("%msisdn%", subscriber["msisdn"])
 
             component = self.encode_map_component(invoke_id, ussd_response)
             response = self.gsup_from_ussd(message, component)
@@ -188,49 +192,64 @@ class SSController(GsupController):
             # through to a quiet end-session response.
             pass
         else:
-            invoke_id = data.get('invokeID') if isinstance(data, dict) else None
-            raise UnknownUSSD(f"Invalid class or constructed {op} with {data}",
-                              error_code=MAP_ERR_UNEXPECTED_DATA_VALUE,
-                              invoke_id=invoke_id)
+            invoke_id = data.get("invokeID") if isinstance(data, dict) else None
+            raise UnknownUSSD(
+                f"Invalid class or constructed {op} with {data}",
+                error_code=MAP_ERR_UNEXPECTED_DATA_VALUE,
+                invoke_id=invoke_id,
+            )
 
         response = self.end_session_response(message)
         await self._send_gsup_response(peer, response)
 
     async def handle_message(self, peer, message):
         message = message.to_dict()
-        ussd_data = GsupMessageUtil.get_first_ie_by_name('supplementary_service_info', message)
+        ussd_data = GsupMessageUtil.get_first_ie_by_name("supplementary_service_info", message)
 
         try:
-            imsi = GsupMessageUtil.get_first_ie_by_name('imsi', message)
+            imsi = GsupMessageUtil.get_first_ie_by_name("imsi", message)
             if imsi is None:
-                raise USSDError("IMSI not found in SS message",
-                                error_code=MAP_ERR_DATA_MISSING)
+                raise USSDError(
+                    "IMSI not found in SS message",
+                    error_code=MAP_ERR_DATA_MISSING,
+                )
 
             # Currently, we only support non-continuous sessions
-            session_state = GsupMessageUtil.get_first_ie_by_name('session_state', message)
+            session_state = GsupMessageUtil.get_first_ie_by_name("session_state", message)
             if session_state is None:
-                raise USSDError("Session state not found in SS message",
-                                error_code=MAP_ERR_DATA_MISSING)
+                raise USSDError(
+                    "Session state not found in SS message",
+                    error_code=MAP_ERR_DATA_MISSING,
+                )
 
-            session_id = GsupMessageUtil.get_first_ie_by_name('session_id', message)
+            session_id = GsupMessageUtil.get_first_ie_by_name("session_id", message)
             if session_id is None:
-                raise USSDError("Session id not found in SS message",
-                                error_code=MAP_ERR_DATA_MISSING)
+                raise USSDError(
+                    "Session id not found in SS message",
+                    error_code=MAP_ERR_DATA_MISSING,
+                )
 
             subscriber = self._database.Get_Subscriber(imsi=imsi)
             if subscriber is None:
-                raise USSDError(f"No subscriber found for IMSI={imsi}",
-                                error_code=MAP_ERR_UNKNOWN_SUBSCRIBER)
+                raise USSDError(
+                    f"No subscriber found for IMSI={imsi}",
+                    error_code=MAP_ERR_UNKNOWN_SUBSCRIBER,
+                )
 
             await self.handle_ussd(peer, message, subscriber, ussd_data)
 
         except USSDError as e:
-            await self._logger.logAsync(service='GSUP', level='ERROR',
-                                        message=f"Error while handling USSD from {peer}: {traceback.format_exc()}")
+            await self._logger.logAsync(
+                service="GSUP",
+                level="ERROR",
+                message=f"Error while handling USSD from {peer}: {traceback.format_exc()}",
+            )
             invoke_id = e.invoke_id if e.invoke_id is not None else self._peek_invoke_id(ussd_data)
             await self._send_error(peer, message, invoke_id, e.error_code)
         except Exception:
-            await self._logger.logAsync(service='GSUP', level='ERROR',
-                                        message=f"Error while handling USSD from {peer}: {traceback.format_exc()}")
-            await self._send_error(peer, message, self._peek_invoke_id(ussd_data),
-                                   MAP_ERR_SYSTEM_FAILURE)
+            await self._logger.logAsync(
+                service="GSUP",
+                level="ERROR",
+                message=f"Error while handling USSD from {peer}: {traceback.format_exc()}",
+            )
+            await self._send_error(peer, message, self._peek_invoke_id(ussd_data), MAP_ERR_SYSTEM_FAILURE)

--- a/lib/gsup/protocol/gsup_msg.py
+++ b/lib/gsup/protocol/gsup_msg.py
@@ -9,19 +9,19 @@ from osmocom.gsup.message import MsgType, GsupMessage
 class GsupMessageBuilder:
     def __init__(self):
         self.gsup_dict = dict()
-        self.gsup_dict['ies'] = list()
-        self.gsup_dict['msg_type'] = ""
+        self.gsup_dict["ies"] = list()
+        self.gsup_dict["msg_type"] = ""
 
     def with_msg_type(self, msg_type: MsgType):
-        self.gsup_dict['msg_type'] = msg_type.name
+        self.gsup_dict["msg_type"] = msg_type.name
         return self
 
     def with_ie(self, name: str, value, merge: bool = True):
-        if 'ies' not in self.gsup_dict:
-            self.gsup_dict['ies'] = []
+        if "ies" not in self.gsup_dict:
+            self.gsup_dict["ies"] = []
 
         if merge:
-            for ie in self.gsup_dict['ies']:
+            for ie in self.gsup_dict["ies"]:
                 if name in ie and isinstance(ie[name], list) and isinstance(value, dict):
                     ie[name].append(value)
                     return self
@@ -29,43 +29,36 @@ class GsupMessageBuilder:
                     ie[name].extend(value)
                     return self
 
-        self.gsup_dict['ies'].append({
-            name: value
-        })
+        self.gsup_dict["ies"].append({name: value})
         return self
 
     def with_msisdn_ie(self, msisdn: str):
-        ie = {
-            'bcd_len': (len(msisdn) + 1) // 2,
-            'digits': msisdn
-        }
-        return self.with_ie('msisdn', ie)
+        ie = {"bcd_len": (len(msisdn) + 1) // 2, "digits": msisdn}
+        return self.with_ie("msisdn", ie)
 
     def with_pdp_info_ie(self, pdp_ctx_id: int, pdp_type: str, apn_name: str):
         pdp_info = []
 
-        pdp_info.append({
-            'pdp_context_id': pdp_ctx_id
-        })
+        pdp_info.append({"pdp_context_id": pdp_ctx_id})
 
-        pdp_info.append({
-            'pdp_address': {
-                'address': None,
-                'hdr': {
-                    'pdp_type_nr': pdp_type,
-                    'pdp_type_org': 'ietf'
-                }
+        pdp_info.append(
+            {
+                "pdp_address": {
+                    "address": None,
+                    "hdr": {
+                        "pdp_type_nr": pdp_type,
+                        "pdp_type_org": "ietf",
+                    },
+                },
             }
-        })
+        )
 
-        pdp_info.append({
-            'access_point_name': apn_name
-        })
+        pdp_info.append({"access_point_name": apn_name})
 
-        return self.with_ie('pdp_info', pdp_info, False)
+        return self.with_ie("pdp_info", pdp_info, False)
 
     def build(self) -> GsupMessage:
-        if self.gsup_dict['msg_type'] == "":
+        if self.gsup_dict["msg_type"] == "":
             raise ValueError("msg_type is required")
         return GsupMessage.from_dict(self.gsup_dict)
 
@@ -77,7 +70,7 @@ class GsupMessageUtil:
 
     @staticmethod
     def get_first_ie_by_name(ie_name: str, message: dict):
-        for ie in message['ies']:
+        for ie in message["ies"]:
             if ie_name in ie:
                 return ie[ie_name]
         return None
@@ -85,7 +78,7 @@ class GsupMessageUtil:
     @staticmethod
     def get_ies_by_name(ie_name: str, message: dict):
         ies = []
-        for ie in message['ies']:
+        for ie in message["ies"]:
             if ie_name in ie:
                 ies.append(ie)
         return ies
@@ -107,12 +100,12 @@ class GMMCause(Enum):
     GPRS_NOTALLOWED = 0x07
     GPRS_OTHER_NOTALLOWED = 0x08
     MS_ID_NOT_DERIVED = 0x09
-    IMPL_DETACHED = 0x0a
-    PLMN_NOTALLOWED = 0x0b
-    LA_NOTALLOWED = 0x0c
-    ROAMING_NOTALLOWED = 0x0d
-    NO_GPRS_PLMN = 0x0e
-    NO_SUIT_CELL_IN_LA = 0x0f
+    IMPL_DETACHED = 0x0A
+    PLMN_NOTALLOWED = 0x0B
+    LA_NOTALLOWED = 0x0C
+    ROAMING_NOTALLOWED = 0x0D
+    NO_GPRS_PLMN = 0x0E
+    NO_SUIT_CELL_IN_LA = 0x0F
     MSC_TEMP_NOTREACH = 0x10
     NET_FAIL = 0x11
     MAC_FAIL = 0x14
@@ -120,13 +113,13 @@ class GMMCause(Enum):
     CONGESTION = 0x16
     GSM_AUTH_UNACCEPT = 0x17
     NOT_AUTH_FOR_CSG = 0x19
-    SMS_VIA_GPRS_IN_RA = 0x1c
+    SMS_VIA_GPRS_IN_RA = 0x1C
     NO_PDP_ACTIVATED = 0x28
-    SEM_INCORR_MSG = 0x5f
+    SEM_INCORR_MSG = 0x5F
     INV_MAND_INFO = 0x60
     MSGT_NOTEXIST_NOTIMPL = 0x61
     MSGT_INCOMP_P_STATE = 0x62
     IE_NOTEXIST_NOTIMPL = 0x63
     COND_IE_ERR = 0x64
     MSG_INCOMP_P_STATE = 0x65
-    PROTO_ERR_UNSPEC = 0x6f
+    PROTO_ERR_UNSPEC = 0x6F

--- a/lib/gsup/protocol/gsup_msg.py
+++ b/lib/gsup/protocol/gsup_msg.py
@@ -8,8 +8,8 @@ from osmocom.gsup.message import MsgType, GsupMessage
 
 class GsupMessageBuilder:
     def __init__(self):
-        self.gsup_dict = dict()
-        self.gsup_dict["ies"] = list()
+        self.gsup_dict = {}
+        self.gsup_dict["ies"] = []
         self.gsup_dict["msg_type"] = ""
 
     def with_msg_type(self, msg_type: MsgType):

--- a/lib/gsup/protocol/gsup_msg.py
+++ b/lib/gsup/protocol/gsup_msg.py
@@ -3,7 +3,8 @@
 # Copyright 2025-2026 Alexander Couzens <lynxis@fe80.eu>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 from enum import Enum
-from osmocom.gsup.message import MsgType, GsupMessage
+
+from osmocom.gsup.message import GsupMessage, MsgType
 
 
 class GsupMessageBuilder:

--- a/lib/pyhss_config.py
+++ b/lib/pyhss_config.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import os
 import sys
-import yaml
 from pathlib import Path
 
+import yaml
 from gsup.protocol.gsup_msg import GMMCause
 
 config = None

--- a/lib/pyhss_config.py
+++ b/lib/pyhss_config.py
@@ -46,10 +46,14 @@ def validate_config():
     preventing silent misconfiguration. Add future validations here."""
 
     valid_reject_causes = {"IMSI_UNKNOWN", "ROAMING_NOT_ALLOWED"}
-    reject_cause = config.get('hss', {}).get('roaming', {}).get('inbound', {}).get('reject_unknown_imsis_with', 'IMSI_UNKNOWN')
+    reject_cause = (
+        config.get("hss", {}).get("roaming", {}).get("inbound", {}).get("reject_unknown_imsis_with", "IMSI_UNKNOWN")
+    )
     if reject_cause not in valid_reject_causes:
-        print(f"ERROR: invalid value for hss.roaming.inbound.reject_unknown_imsis_with: '{reject_cause}'. "
-              f"Valid options are: {', '.join(sorted(valid_reject_causes))}")
+        print(
+            f"ERROR: invalid value for hss.roaming.inbound.reject_unknown_imsis_with: '{reject_cause}'. "
+            f"Valid options are: {', '.join(sorted(valid_reject_causes))}"
+        )
         sys.exit(1)
 
 
@@ -58,7 +62,10 @@ validate_config()
 
 
 def get_unknown_subscriber_2g_reject_cause() -> GMMCause:
-    if config.get('hss', {}).get('roaming', {}).get('inbound', {}).get('reject_unknown_imsis_with', 'IMSI_UNKNOWN') == 'ROAMING_NOT_ALLOWED':
+    if (
+        config.get("hss", {}).get("roaming", {}).get("inbound", {}).get("reject_unknown_imsis_with", "IMSI_UNKNOWN")
+        == "ROAMING_NOT_ALLOWED"
+    ):
         return GMMCause.ROAMING_NOTALLOWED
     else:
         return GMMCause.IMSI_UNKNOWN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ include = [
 [tool.ruff.lint]
 ignore = [
 	"BLE001",  # https://docs.astral.sh/ruff/rules/blind-except/
-	"C408",    # https://docs.astral.sh/ruff/rules/unnecessary-collection-call/
 	"FURB129", # https://docs.astral.sh/ruff/rules/readlines-in-for/
 	"I001",    # https://docs.astral.sh/ruff/rules/unsorted-imports/
 	"N999",    # https://docs.astral.sh/ruff/rules/invalid-module-name/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ include = [
 [tool.ruff.lint]
 ignore = [
 	"BLE001",  # https://docs.astral.sh/ruff/rules/blind-except/
-	"I001",    # https://docs.astral.sh/ruff/rules/unsorted-imports/
 	"N999",    # https://docs.astral.sh/ruff/rules/invalid-module-name/
 	"PLW1510", # https://docs.astral.sh/ruff/rules/subprocess-run-without-check/
 	"S110",    # https://docs.astral.sh/ruff/rules/try-except-pass/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ include = [
 [tool.ruff.lint]
 ignore = [
 	"BLE001",  # https://docs.astral.sh/ruff/rules/blind-except/
-	"FURB129", # https://docs.astral.sh/ruff/rules/readlines-in-for/
 	"I001",    # https://docs.astral.sh/ruff/rules/unsorted-imports/
 	"N999",    # https://docs.astral.sh/ruff/rules/invalid-module-name/
 	"PLW1510", # https://docs.astral.sh/ruff/rules/subprocess-run-without-check/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,5 @@ include = [
 ignore = [
 	"BLE001",  # https://docs.astral.sh/ruff/rules/blind-except/
 	"N999",    # https://docs.astral.sh/ruff/rules/invalid-module-name/
-	"PLW1510", # https://docs.astral.sh/ruff/rules/subprocess-run-without-check/
 	"S110",    # https://docs.astral.sh/ruff/rules/try-except-pass/
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,5 +68,4 @@ include = [
 ignore = [
 	"BLE001",  # https://docs.astral.sh/ruff/rules/blind-except/
 	"N999",    # https://docs.astral.sh/ruff/rules/invalid-module-name/
-	"S110",    # https://docs.astral.sh/ruff/rules/try-except-pass/
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,14 @@ include = [
 	"tests/test_license_headers.py",
 	"tests/test_milenage.py",
 ]
+
+[tool.ruff.lint]
+ignore = [
+	"BLE001",  # https://docs.astral.sh/ruff/rules/blind-except/
+	"C408",    # https://docs.astral.sh/ruff/rules/unnecessary-collection-call/
+	"FURB129", # https://docs.astral.sh/ruff/rules/readlines-in-for/
+	"I001",    # https://docs.astral.sh/ruff/rules/unsorted-imports/
+	"N999",    # https://docs.astral.sh/ruff/rules/invalid-module-name/
+	"PLW1510", # https://docs.astral.sh/ruff/rules/subprocess-run-without-check/
+	"S110",    # https://docs.astral.sh/ruff/rules/try-except-pass/
+]

--- a/tests/test_database_upgrade_mariadb.py
+++ b/tests/test_database_upgrade_mariadb.py
@@ -1,15 +1,16 @@
 # Copyright 2025 sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import os
-import pytest
 import shlex
 import shutil
-import sqlglot
 import subprocess
+from pathlib import Path
+
+import pytest
+import sqlglot
 from conftest import wait_for_tcp_port
 from database import Database
 from logtool import LogTool
-from pathlib import Path
 from pyhss_config import config
 
 top_dir = Path(Path(__file__) / "../..").resolve()

--- a/tests/test_database_upgrade_postgresql.py
+++ b/tests/test_database_upgrade_postgresql.py
@@ -3,15 +3,15 @@
 import glob
 import importlib
 import os
-import pytest
 import re
-import sqlglot
 import subprocess
+from pathlib import Path
 
+import pytest
+import sqlglot
 from conftest import wait_for_tcp_port
 from database import Database
 from logtool import LogTool
-from pathlib import Path
 from pyhss_config import config
 
 top_dir = Path(Path(__file__) / "../..").resolve()

--- a/tests/test_database_upgrade_sqlite.py
+++ b/tests/test_database_upgrade_sqlite.py
@@ -1,11 +1,12 @@
 # Copyright 2025 sysmocom - s.f.m.c. GmbH <info@sysmocom.de>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import os
-import pytest
 import re
 import sqlite3
 import subprocess
 from pathlib import Path
+
+import pytest
 from database import Database
 from logtool import LogTool
 from pyhss_config import config

--- a/tests/test_database_upgrade_sqlite.py
+++ b/tests/test_database_upgrade_sqlite.py
@@ -83,7 +83,10 @@ def sqlite_dump_and_compare_with_latest(tmpdir):
     current_sql, current_path = sqlite_dump(tmpdir)
 
     if current_sql != latest_sql:
-        subprocess.run(["git", "diff", "--no-index", "--color=always", latest_path, current_path])
+        subprocess.run(
+            ["git", "diff", "--no-index", "--color=always", latest_path, current_path],
+            check=False,
+        )
         print()
         print("ERROR: The database schema has changed. Please add upgrade logic as described here:")
         print("https://github.com/nickvsnetworking/pyhss/blob/master/docs/databases.md")

--- a/tests/test_gsup_ussd.py
+++ b/tests/test_gsup_ussd.py
@@ -13,8 +13,10 @@ from smspdudecoder.codecs import GSM
 from gsup.controller.ss import USSD, SSController, UnknownUSSD
 from gsup.protocol.gsup_msg import GsupMessageBuilder, GsupMessageUtil
 
-DEFAULT_TARGETS = {"*#100#": "Your MSISDN is: %msisdn%",
-                   "*#101#": "Your IMSI is: %imsi%"}
+DEFAULT_TARGETS = {
+    "*#100#": "Your MSISDN is: %msisdn%",
+    "*#101#": "Your IMSI is: %imsi%",
+}
 DEFAULT_TARGETS_SINGLE = {"*#100#": "Your MSISDN is: %msisdn%"}
 DEFAULT_SUBSCRIBER = {"imsi": "262423403000001", "msisdn": "12345"}
 
@@ -30,9 +32,11 @@ def _build_controller(targets, subscriber_data=None):
     controller.targets = targets
     controller._sent_responses = []
     original_send = controller._send_gsup_response
+
     async def capture_send(peer, response):
         controller._sent_responses.append(response)
         await original_send(peer, response)
+
     controller._send_gsup_response = capture_send
     return controller
 
@@ -50,8 +54,7 @@ def _get_ie(response, name):
     return next((ie for ie in response.to_dict()["ies"] if name in ie), None)
 
 
-def _make_message_dict(imsi="262423403000001", session_state="start", session_id=1,
-                       supplementary_service_info=None):
+def _make_message_dict(imsi="262423403000001", session_state="start", session_id=1, supplementary_service_info=None):
     """Build a minimal GsupMessage dict for testing."""
     ies = []
     if imsi is not None:
@@ -112,8 +115,7 @@ class TestUSSDControllerInit(TestCase):
         }
         mock_config.get.return_value = {"gsup": {"ussd": ussd_config}}
         controller = SSController(logger=None, database=None)
-        expected_targets = {"*#100#": "MSISDN: %msisdn%",
-                            "*#101#": "IMSI: %imsi%"}
+        expected_targets = {"*#100#": "MSISDN: %msisdn%", "*#101#": "IMSI: %imsi%"}
         self.assertEqual(controller.targets, expected_targets)
 
 
@@ -121,8 +123,7 @@ class TestHandleMessage(TestCase):
     """Test handle_message entry point."""
 
     def _build(self):
-        return _build_controller(
-            DEFAULT_TARGETS, DEFAULT_SUBSCRIBER)
+        return _build_controller(DEFAULT_TARGETS, DEFAULT_SUBSCRIBER)
 
     def test_handle_message_missing_imsi(self):
         controller = self._build()
@@ -166,8 +167,7 @@ class TestHandleMessage(TestCase):
         controller = self._build()
         peer = _make_peer()
         ussd_data = _encode_ussd_invoke(4, "*#100#")
-        message = GsupMessage.from_dict(
-            _make_message_dict(session_id=None, supplementary_service_info=ussd_data))
+        message = GsupMessage.from_dict(_make_message_dict(session_id=None, supplementary_service_info=ussd_data))
         asyncio.run(controller.handle_message(peer, message))
 
         self.assertEqual(len(controller._sent_responses), 1)
@@ -355,8 +355,7 @@ class TestHandleUSSD(TestCase):
     """Test handle_ussd internal logic."""
 
     def test_handle_ussd_valid_invoke(self):
-        controller = _build_controller(
-            DEFAULT_TARGETS_SINGLE)
+        controller = _build_controller(DEFAULT_TARGETS_SINGLE)
         peer = _make_peer()
         subscriber = {"imsi": "262423403000001", "msisdn": "12345"}
         message = _make_message_dict()
@@ -371,8 +370,7 @@ class TestHandleUSSD(TestCase):
         self.assertEqual(decoded_response, "Your MSISDN is: 12345")
 
     def test_handle_ussd_invalid_op_code(self):
-        controller = _build_controller(
-            DEFAULT_TARGETS_SINGLE)
+        controller = _build_controller(DEFAULT_TARGETS_SINGLE)
         peer = _make_peer()
         subscriber = {"imsi": "262423403000001", "msisdn": "12345"}
         message = _make_message_dict()
@@ -392,8 +390,7 @@ class TestHandleUSSD(TestCase):
             asyncio.run(controller.handle_ussd(peer, message, subscriber, ussd_data))
 
     def test_handle_ussd_return_result_last(self):
-        controller = _build_controller(
-            DEFAULT_TARGETS_SINGLE)
+        controller = _build_controller(DEFAULT_TARGETS_SINGLE)
         peer = _make_peer()
         subscriber = {"imsi": "262423403000001", "msisdn": "12345"}
         message = _make_message_dict()
@@ -470,6 +467,7 @@ class TestStaticMethods(TestCase):
         decoded_str = GSM().decode(str(binascii.b2a_hex(ussd_arg["ussd-String"]), "utf-8"))
         self.assertEqual(decoded_str, answer)
 
+
 class TestMessageLengths(TestCase):
     """Test GSM encoding/decoding with different message lengths.
 
@@ -478,8 +476,7 @@ class TestMessageLengths(TestCase):
     """
 
     def test_short_message(self):
-        controller = _build_controller(
-            DEFAULT_TARGETS, "Code not recognized.")
+        controller = _build_controller(DEFAULT_TARGETS, "Code not recognized.")
         peer = _make_peer()
         ussd_data = _encode_ussd_invoke(1, "*#100#")
         message = _make_message_dict()
@@ -493,8 +490,7 @@ class TestMessageLengths(TestCase):
         self.assertEqual(decoded_response, "Your MSISDN is: 12345")
 
     def test_long_message(self):
-        controller = _build_controller(
-            DEFAULT_TARGETS, "Code not recognized.")
+        controller = _build_controller(DEFAULT_TARGETS, "Code not recognized.")
         peer = _make_peer()
         ussd_data = _encode_ussd_invoke(1, "*#100#")
         message = _make_message_dict()
@@ -514,8 +510,7 @@ class TestMessageLengths(TestCase):
             msg = "A" * length
             encoded = SSController.encode_ussd_arg(msg)
             ussd_arg = USSD.decode("USSD-Arg", encoded)
-            decoded = GSM().decode(str(binascii.b2a_hex(ussd_arg["ussd-String"]), "utf-8"),
-                                   strip_padding=True)
+            decoded = GSM().decode(str(binascii.b2a_hex(ussd_arg["ussd-String"]), "utf-8"), strip_padding=True)
             self.assertEqual(decoded, msg, f"Round-trip failed for length {length}")
 
 

--- a/tests/test_gsup_ussd.py
+++ b/tests/test_gsup_ussd.py
@@ -7,11 +7,10 @@ from collections import OrderedDict
 from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from osmocom.gsup.message import GsupMessage, MsgType
-from smspdudecoder.codecs import GSM
-
 from gsup.controller.ss import USSD, SSController, UnknownUSSD
 from gsup.protocol.gsup_msg import GsupMessageBuilder, GsupMessageUtil
+from osmocom.gsup.message import GsupMessage, MsgType
+from smspdudecoder.codecs import GSM
 
 DEFAULT_TARGETS = {
     "*#100#": "Your MSISDN is: %msisdn%",

--- a/tests/test_license_headers.py
+++ b/tests/test_license_headers.py
@@ -10,7 +10,7 @@ def file_has_headers(path):
     with open(path) as f:
         missing_copyright = True
         missing_license = True
-        for line in f.readlines():
+        for line in f:
             if missing_copyright and line.startswith("# Copyright "):
                 missing_copyright = False
             elif missing_license and line.startswith("# SPDX-License-Identifier: "):


### PR DESCRIPTION
We have added some of the newer python files to `tool.ruff.include` in `pyproject.toml`, so when running `ruff check` and `ruff format --check`, the ruff linter checks them. This PR makes recently released ruff 0.16 pass with the codebase again:

* Format the files that were added to `tool.ruff.include` in #302 using `ruff format`
* Adjust to the [new default rule set](https://astral.sh/blog/ruff-v0.16.0#better-default-rule-set) in ruff 0.16 that caused new failures by either fixing them or ignoring them for now

Ensure these files keep passing the linter in the future as well by adding a CI check.