### PR TITLE
pyproject: ignore new warnings from asn1tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,14 @@ env = [
 filterwarnings = [
 	# Warning appears inside SQLAlchemy code, also might not make sense:
 	# https://github.com/python/cpython/issues/135834
-	"ignore:The default datetime adapter is deprecated as of Python 3.12"
+	"ignore:The default datetime adapter is deprecated as of Python 3.12",
+
+	# PyparsingDeprecationWarnings appearing inside asn1tools
+	"ignore:'delimitedList' deprecated - use 'DelimitedList'",
+	"ignore:'excludeChars' argument is deprecated, use 'exclude_chars'",
+	"ignore:'parseString' deprecated - use 'parse_string'",
+	"ignore:'setName' deprecated - use 'set_name'",
+	"ignore:'setParseAction' deprecated - use 'set_parse_action'",
 ]
 markers = [
     "slow",


### PR DESCRIPTION
Since d979cd36 ("feat(2g): implement USSD support") we get 181 warnings from asn1tools when running the testsuite that look like this:

```
.venv/lib/python3.14/site-packages/asn1tools/parser.py:1857
  /home/user/code/osmo-dev/src/pyhss/.venv/lib/python3.14/site-packages/asn1tools/parser.py:1857: PyparsingDeprecationWarning: 'parseString' deprecated - use 'parse_string'
    tokens = grammar.parseString(string).asList()
```

This needs to be fixed inside asn1tools, having these warnings show up when running the PyHSS testsuite is not helpful.