### PR TITLE
tests: postgres: try createdb multiple times

### DIFF
--- a/tests/test_database_upgrade_postgresql.py
+++ b/tests/test_database_upgrade_postgresql.py
@@ -4,6 +4,7 @@ import glob
 import importlib
 import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -41,9 +42,20 @@ def run_postgresql(tmpdir):
 
     try:
         wait_for_tcp_port(postgresql_port)
-        cmd = [createdb[0], "-h127.0.0.1", f"-p{postgresql_port}", "-Uuser", "hss"]
-        print(f"+ {cmd}")
-        subprocess.run(cmd, check=True)
+        tries = 5
+        for i in range(tries):
+            cmd = [createdb[0], "-h127.0.0.1", f"-p{postgresql_port}", "-Uuser", "hss"]
+            print(f"+ {cmd}")
+            createdb_proc = subprocess.run(cmd, check=False)
+            if createdb_proc.returncode == 0:
+                break
+            print(f"createdb failed ({i + 1}/{tries}) with returncode: {createdb_proc.returncode}")
+            if i + 1 < tries:
+                print("Database might still be starting up, trying again in 1s…")
+                time.sleep(1)
+            else:
+                print("Giving up")
+                raise RuntimeError("createdb failed!")
         yield
     finally:
         proc.kill()

--- a/tests/test_database_upgrade_postgresql.py
+++ b/tests/test_database_upgrade_postgresql.py
@@ -3,7 +3,6 @@
 import glob
 import importlib
 import os
-import re
 import subprocess
 from pathlib import Path
 
@@ -67,9 +66,6 @@ def postgresql_import(tmpdir, sql_file):
     with open(sql_path_temp, "w") as f:
         sql = sqlglot.transpile(sql, read="sqlite", write="postgres", pretty=True)
         sql = ";\n\n".join(sql) + ";\n"
-        # Workaround for https://github.com/tobymao/sqlglot/issues/6596
-        # Can be removed after sqlglot > v28.5.0 is released
-        sql = re.sub(r"(PRIMARY KEY\s*\(\s*\w+)(\s*NULLS\s+FIRST\s*\))", r"\1)", sql)
         f.write(sql)
 
     psql = glob.glob("/usr/lib/postgresql/*/bin/psql")


### PR DESCRIPTION
 I've seen the createdb command fail occasionally in github's CI.
Apparently postgres can be in a "starting up" state even after the tcp
port is bound:
    
      createdb: error: connection to server at "127.0.0.1", port 54321 failed: FATAL:  the database system is starting up
    
Make the tests pass reliably by running the createdb command up to 5
times with a 1s sleep between each attempt.
    
Related: https://github.com/nickvsnetworking/pyhss/actions/runs/31482527502/job/93750506691